### PR TITLE
feat(onboarding): selettore lingua e tasto rivedi presentazione

### DIFF
--- a/src/app/features/onboarding/onboarding.html
+++ b/src/app/features/onboarding/onboarding.html
@@ -11,6 +11,7 @@
       }
     </div>
     <div class="appbar-r">
+      <app-lang-switch />
       <button class="nav-btn" (click)="done()">{{ i18n.t('skip') }}</button>
     </div>
   </div>

--- a/src/app/features/onboarding/onboarding.ts
+++ b/src/app/features/onboarding/onboarding.ts
@@ -3,6 +3,7 @@ import { Router } from '@angular/router';
 import { I18nService } from '../../core/i18n/i18n.service';
 import { AppStateService } from '../../core/state/app-state.service';
 import { Icon } from '../../shared/icon';
+import { LangSwitch } from '../../shared/lang-switch';
 import { Logo } from '../../shared/logo';
 
 interface OnboardingStep {
@@ -35,7 +36,7 @@ const STEPS: ReadonlyArray<OnboardingStep> = [
 
 @Component({
   selector: 'app-onboarding',
-  imports: [Icon, Logo],
+  imports: [Icon, LangSwitch, Logo],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './onboarding.html',
   styleUrl: './onboarding.css',

--- a/src/app/features/settings/settings.html
+++ b/src/app/features/settings/settings.html
@@ -77,6 +77,13 @@
     </section>
 
     <section class="settings-section">
+      <h3 class="h3">{{ i18n.lang() === 'it' ? 'Aiuto' : 'Help' }}</h3>
+      <button class="btn btn-ghost btn-block" type="button" (click)="replayOnboarding()">
+        {{ i18n.lang() === 'it' ? 'Rivedi la presentazione' : 'Replay the intro' }}
+      </button>
+    </section>
+
+    <section class="settings-section">
       <h3 class="h3">{{ i18n.lang() === 'it' ? 'Dati' : 'Data' }}</h3>
       <button class="btn btn-ghost btn-block reset-btn" type="button" (click)="resetProgress()">
         {{ i18n.lang() === 'it' ? 'Resetta tutti i progressi' : 'Reset all progress' }}

--- a/src/app/features/settings/settings.ts
+++ b/src/app/features/settings/settings.ts
@@ -57,6 +57,10 @@ export class Settings {
     this.appState.update({ showCodepoint: !this.state().showCodepoint });
   }
 
+  protected replayOnboarding(): void {
+    this.router.navigate(['/onboarding']);
+  }
+
   protected resetProgress(): void {
     const msg =
       this.i18n.lang() === 'it'


### PR DESCRIPTION
Due piccole rifiniture all'esperienza di benvenuto.

Nella schermata di onboarding ora compare in alto a destra, accanto al pulsante "Salta", il selettore di lingua (IT/EN): cosi' chi non capisce la lingua di default puo' cambiarla prima ancora di iniziare a leggere il testo, senza dover prima saltare il flusso.

Nelle impostazioni e' apparsa una nuova sezione "Aiuto" con il pulsante "Rivedi la presentazione": cliccandolo si riapre il flusso di benvenuto in due step come la prima volta. Utile per recuperare le indicazioni base sul gioco senza dover resettare tutti i progressi.