### PR TITLE
feat: usa URL puliti senza il cancelletto

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ Niente backend per ora: tutto in-memory, persistenza via `localStorage` per stat
 
 - **Angular 21.2+**, standalone components, `ChangeDetectionStrategy.OnPush` ovunque, **zoneless change detection** (`provideZonelessChangeDetection`).
 - **Signals** (`signal`, `computed`, `effect`) per stato reattivo. Niente NgRx; RxJS solo come dipendenza implicita del Router (`toSignal(this.route.paramMap)` e' il pattern per leggere query/path params).
-- **Routing**: `provideRouter` con **`withHashLocation()`**: gli URL hanno la forma `/#/home`, `/#/game?mode=training`, ecc. Scelta motivata da GitHub Pages: niente trick di `404.html`, il refresh diretto su una qualunque route funziona sempre.
+- **Routing**: `provideRouter` con path location standard (no `#` nelle URL) e scroll restoration "top". Su GitHub Pages il refresh su una route deep funziona via `public/404.html`: quando Pages non trova il path sul filesystem serve il 404, che salva l'URL richiesto in `sessionStorage` (chiave `gtc-redirect`) e fa redirect a `/guess-the-char/`. Lo script in `src/index.html` ripristina il path originale via `history.replaceState` prima del bootstrap Angular.
 - **Styling**: un singolo `src/styles.css` globale (importato dal prototipo Claude Design as-is, classi `.btn`, `.card`, `.pill`, `.glyph-stage`, ecc., ~42KB) + CSS scoped per i componenti che hanno bisogno di layout o animazioni specifiche.
 - **Build/test**: nuovo builder `@angular/build` (esbuild + vite dev server). Vitest e' presente come devDep ma non sono ancora configurati test; `tsconfig.spec.json` resta come placeholder.
 - **Niente lint configurato**, Prettier presente come devDep ma non invocato da CI (usato come default dell'editor). Editor config in `.editorconfig`.
@@ -42,7 +42,7 @@ src/
   main.ts                   # bootstrap dell'app standalone
   styles.css                # stylesheet globale del design (~42 KB)
   app/
-    app.config.ts           # provideRouter (hash), provideZonelessChangeDetection
+    app.config.ts           # provideRouter (path location + scroll top), provideZonelessChangeDetection
     app.routes.ts           # tabella route + onboardedGuard
     app.ts                  # root component: router-outlet + footer build stamp + applica i token CSS del tema
     core/
@@ -298,14 +298,14 @@ Cose da sapere se lo modifichi:
 - Il build di produzione viene fatto con `--base-href=/guess-the-char/`: lo richiede il fatto che il sito vive su un sottopath del dominio `*.github.io`. Se cambia il nome del repo, va aggiornato anche qui.
 - Il workflow chiama `npm run build` (non `npx ng build`): cosi' parte lo step `prebuild` di `package.json` che scrive `build-sha.local.ts` (vedi sezione "Build info").
 - L'output di Angular 21 con builder `@angular/build` finisce in `dist/guess-the-char/browser/`: e' la cartella caricata come artifact Pages.
-- **Niente `404.html` fallback SPA**: il routing usa `withHashLocation()`, quindi tutti i deep link vivono dopo il `#` e il path effettivo servito da Pages e' sempre `index.html`. Se in futuro si volesse passare a `PathLocationStrategy` servira' aggiungere il trick `404.html` (vedi rafgraph-style).
+- `public/404.html` e' il fallback SPA "rafgraph-style": GitHub Pages lo serve per qualunque path inesistente, lui salva `location.pathname + search + hash` in `sessionStorage.gtc-redirect` e redireziona a `/guess-the-char/`. `src/index.html` legge quel valore prima del bootstrap Angular e ripristina l'URL via `history.replaceState`. Cosi' i deep link `/guess-the-char/game` funzionano anche al refresh diretto. Viene copiato automaticamente nel `dist/` come asset.
 - `.nojekyll` (vuoto, presente alla root) impedisce a Pages di processare i file via Jekyll. Lo step del workflow lo copia automaticamente in `_site/`.
 - Prima pubblicazione: in *Settings > Pages* del repo va scelto "Source: GitHub Actions" una volta sola.
 
 ## Vincoli e cose da non fare
 
 - **Non** introdurre RxJS observable per stato applicativo: usa signal/effect. RxJS resta ammesso solo dove serve a integrare API Angular che lo richiedono (es. `toSignal` su params di `Router`).
-- **Non** rimuovere `withHashLocation()` da `app.config.ts` senza prima decidere come gestire le route refresh-friendly su Pages (servirebbe un `404.html` che ridireziona a `index.html`, e per ora non c'e').
+- **Non** rimuovere lo script SPA-fallback in `src/index.html` ne' lo script di `public/404.html` senza aver configurato un'alternativa al routing path-location: rompe il refresh diretto su route diverse da `/`.
 - **Non** bypassare `AppStateService` con scritture dirette a `localStorage`: la chiave `gtc.state` ha uno schema mergiato col `DEFAULT_STATE` ed evita di rompere lo stato di utenti gia' utilizzatori.
 - **Non** introdurre librerie UI esterne (Material, PrimeNG, Tailwind) senza necessita': il design system del prototipo e' gia' coerente e pesato.
 - **Non** convertire a SCSS o CSS modules per componente senza un buon motivo: lo styling globale e' una scelta, non un'omissione.

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="it">
+<head>
+  <meta charset="utf-8">
+  <title>Indovina il carattere</title>
+  <meta name="robots" content="noindex">
+  <script>
+    // SPA fallback per GitHub Pages con routing a path location (no #).
+    // Quando un URL non esiste sul filesystem (es. /guess-the-char/game),
+    // Pages serve questo 404.html: noi salviamo il path originale in
+    // sessionStorage e redirezioniamo all'index.html. Lo script di
+    // ripristino in src/index.html lo riapplica via history.replaceState
+    // prima del bootstrap Angular.
+    (function () {
+      var BASE = '/guess-the-char/';
+      var path = location.pathname + location.search + location.hash;
+      try {
+        sessionStorage.setItem('gtc-redirect', path);
+      } catch (e) {
+        // sessionStorage non disponibile: redirect "secco" alla home.
+      }
+      location.replace(BASE);
+    })();
+  </script>
+</head>
+<body></body>
+</html>

--- a/public/404.html
+++ b/public/404.html
@@ -4,6 +4,59 @@
   <meta charset="utf-8">
   <title>Indovina il carattere</title>
   <meta name="robots" content="noindex">
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet"
+        href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,600;12..96,700&family=Geist:wght@400;500&display=swap">
+  <style>
+    html, body {
+      margin: 0;
+      min-height: 100dvh;
+      background: #0b0f14;
+      color: #e7eef6;
+      font-family: 'Geist', 'Bricolage Grotesque', system-ui, sans-serif;
+    }
+    body {
+      display: grid;
+      place-items: center;
+      padding: 24px;
+    }
+    .stage {
+      max-width: 360px;
+      text-align: center;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 14px;
+    }
+    .glyph {
+      font-family: 'Bricolage Grotesque', system-ui, sans-serif;
+      font-size: 120px;
+      font-weight: 700;
+      line-height: 1;
+      color: #fbbf24;
+      margin-bottom: 4px;
+    }
+    h1 {
+      font-family: 'Bricolage Grotesque', system-ui, sans-serif;
+      font-weight: 600;
+      font-size: 22px;
+      margin: 0;
+    }
+    p { color: #94a3b8; font-size: 14px; margin: 0; line-height: 1.5; }
+    a.home-link {
+      margin-top: 14px;
+      padding: 12px 20px;
+      border-radius: 14px;
+      background: #fbbf24;
+      color: #3a2407;
+      font-weight: 600;
+      text-decoration: none;
+      font-size: 14px;
+    }
+    a.home-link:hover { background: #f59e0b; }
+  </style>
   <script>
     // SPA fallback per GitHub Pages con routing a path location (no #).
     // Quando un URL non esiste sul filesystem (es. /guess-the-char/game),
@@ -11,6 +64,9 @@
     // sessionStorage e redirezioniamo all'index.html. Lo script di
     // ripristino in src/index.html lo riapplica via history.replaceState
     // prima del bootstrap Angular.
+    //
+    // Il body sotto si vede solo se JS e' disabilitato (in pratica mai),
+    // ma e' brand-coerente per pareggiare il flash di transizione.
     (function () {
       var BASE = '/guess-the-char/';
       var path = location.pathname + location.search + location.hash;
@@ -23,5 +79,13 @@
     })();
   </script>
 </head>
-<body></body>
+<body>
+  <div class="stage">
+    <span class="glyph">字</span>
+    <h1>Indovina il carattere</h1>
+    <p>La pagina che cerchi non esiste, ti riportiamo alla home.</p>
+    <p>Se non vedi il reindirizzamento, JavaScript e' disabilitato.</p>
+    <a class="home-link" href="/guess-the-char/">Torna alla home</a>
+  </div>
+</body>
 </html>

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,5 +1,5 @@
 import { ApplicationConfig, provideBrowserGlobalErrorListeners, provideZonelessChangeDetection } from '@angular/core';
-import { provideRouter, withHashLocation } from '@angular/router';
+import { provideRouter, withInMemoryScrolling } from '@angular/router';
 
 import { routes } from './app.routes';
 
@@ -7,6 +7,9 @@ export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
     provideZonelessChangeDetection(),
-    provideRouter(routes, withHashLocation()),
+    provideRouter(
+      routes,
+      withInMemoryScrolling({ scrollPositionRestoration: 'top', anchorScrolling: 'enabled' }),
+    ),
   ],
 };

--- a/src/index.html
+++ b/src/index.html
@@ -15,6 +15,24 @@
   <!-- Noto fallback selettivo per gli script non-Latin, cosi' le metriche dei glifi restano coerenti. -->
   <link rel="stylesheet"
         href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500&family=Noto+Sans+KR:wght@400;500&family=Noto+Sans+SC:wght@400;500&family=Noto+Sans+Devanagari:wght@400;500&family=Noto+Sans+Bengali:wght@400;500&family=Noto+Sans+Tamil:wght@400;500&family=Noto+Sans+Thai:wght@400;500&family=Noto+Sans+Lao:wght@400;500&family=Noto+Sans+Khmer:wght@400;500&family=Noto+Sans+Arabic:wght@400;500&family=Noto+Sans+Hebrew:wght@400;500&family=Noto+Sans+Armenian:wght@400;500&family=Noto+Sans+Georgian:wght@400;500&family=Noto+Sans+Gurmukhi:wght@400;500&display=swap" />
+
+  <script>
+    // SPA fallback restore: se public/404.html ha salvato un path in
+    // sessionStorage prima di riportarci alla root, qui lo riapplichiamo
+    // via history.replaceState prima del bootstrap Angular. In dev
+    // (ng serve) sessionStorage e' vuoto e questo blocco non fa nulla.
+    (function () {
+      try {
+        var redirect = sessionStorage.getItem('gtc-redirect');
+        if (redirect) {
+          sessionStorage.removeItem('gtc-redirect');
+          history.replaceState(null, '', redirect);
+        }
+      } catch (e) {
+        // sessionStorage non disponibile, accettiamo il path attuale.
+      }
+    })();
+  </script>
 </head>
 <body>
   <app-root></app-root>


### PR DESCRIPTION
I link dell'app ora hanno la forma "guess-the-char.app/game" invece di "guess-the-char.app/#/game": URL piu' leggibili e condivisibili, niente cancelletto in mezzo. Il sito si comporta come una normale single-page application: ricaricando un link diretto (anche a una pagina interna) si arriva correttamente dove serve.

Sotto al cofano: aggiunto il classico fallback "rafgraph" che gestisce questa situazione su GitHub Pages, dato che il server non sa che le rotte sono client-side. Per il refresh diretto su una rotta deep, Pages serve un piccolo 404.html che salva l'URL e redireziona alla home; lo script in index.html riapplica l'URL prima che Angular parta.

Quando il sito sara' pubblicato, eventuali link salvati nella forma vecchia con il cancelletto continueranno a portare alla home: niente di rotto, semplicemente non puntano piu' alla pagina interna.