### PR TITLE
feat(home): pulizia header e modali info sui contatori

### DIFF
--- a/src/app/features/home/home.css
+++ b/src/app/features/home/home.css
@@ -32,6 +32,17 @@
   gap: 6px;
 }
 
+/* Il badge "Completata" / "Giorni consecutivi" e' ora un button cliccabile
+   per aprire la modale informativa. Manteniamo l'aspetto della .pill. */
+.daily-status {
+  border: 1px solid transparent;
+  cursor: pointer;
+  font: inherit;
+  transition: filter var(--hover-dur) ease, transform var(--hover-dur) ease;
+}
+.daily-status:hover { filter: brightness(1.1); }
+.daily-status:active { transform: translateY(1px); }
+
 .mode-list {
   display: flex;
   flex-direction: column;
@@ -50,6 +61,17 @@
   grid-template-columns: 1fr 1fr 1fr;
   gap: 8px;
 }
+/* Le tre stat sono cliccabili per aprire la modale info; restano visivamente
+   identiche al box stat globale di styles.css ma diventano focus-friendly. */
+.stats-grid > .stat {
+  cursor: pointer;
+  font: inherit;
+  color: inherit;
+  text-align: left;
+  transition: background var(--hover-dur) ease, transform var(--hover-dur) ease;
+}
+.stats-grid > .stat:hover { background: var(--surface-2); }
+.stats-grid > .stat:active { transform: translateY(1px); }
 
 /* Il container .badges-teaser e i cerchi `.icons > span[data-on][data-t]` sono
    stylati in styles.css globale, identici al prototipo. Qui solo i piccoli

--- a/src/app/features/home/home.html
+++ b/src/app/features/home/home.html
@@ -1,6 +1,5 @@
 <div class="app-shell">
   <app-bar>
-    <app-streak-pill [value]="state().streak" />
     <app-lang-switch />
     <button
       class="btn-icon"
@@ -23,25 +22,21 @@
       </h1>
     </div>
 
-    <div
-      class="daily"
-      role="button"
-      tabindex="0"
-      (click)="goDaily()"
-      (keydown.enter)="goDaily()"
-    >
+    <div class="daily">
       <div class="daily-head">
         <span class="eyebrow">{{ i18n.t('daily').toUpperCase() }}</span>
         @if (state().dailyDone) {
-          <span class="pill success">
+          <button type="button" class="pill success daily-status" (click)="openInfo('dailyStreak', $event)">
             <span class="dot"></span>
             {{ i18n.lang() === 'it' ? 'Completata' : 'Done' }}
-          </span>
+          </button>
         } @else {
-          <span class="pill warm">
+          <button type="button" class="pill warm daily-status" (click)="openInfo('dailyStreak', $event)">
             <span class="dot"></span>
-            <span>Streak {{ state().dailyStreak }}</span>
-          </span>
+            <span>
+              {{ i18n.lang() === 'it' ? 'Giorni consecutivi' : 'Days in a row' }} {{ state().dailyStreak }}
+            </span>
+          </button>
         }
       </div>
       <h2 class="h2 daily-title">
@@ -58,7 +53,7 @@
             }
           }
         </div>
-        <span class="btn btn-primary daily-cta">
+        <button type="button" class="btn btn-primary daily-cta" (click)="goDaily()">
           <span>
             {{
               state().dailyDone
@@ -67,7 +62,7 @@
             }}
           </span>
           <app-icon name="arrow-right" />
-        </span>
+        </button>
       </div>
     </div>
 
@@ -133,18 +128,18 @@
       </button>
     </div>
     <div class="stats-grid">
-      <div class="stat">
+      <button class="stat" type="button" (click)="openInfo('streak')">
         <span class="v">{{ state().streak }}</span>
         <span class="l">{{ i18n.t('streak') }}</span>
-      </div>
-      <div class="stat">
+      </button>
+      <button class="stat" type="button" (click)="openInfo('accuracy')">
         <span class="v">{{ state().accuracy }}%</span>
         <span class="l">{{ i18n.t('accuracy') }}</span>
-      </div>
-      <div class="stat">
+      </button>
+      <button class="stat" type="button" (click)="openInfo('played')">
         <span class="v">{{ state().played }}</span>
         <span class="l">{{ i18n.t('played') }}</span>
-      </div>
+      </button>
     </div>
 
     <div class="section-head">
@@ -184,4 +179,8 @@
 
     <p class="home-version mono" aria-label="Versione applicazione">{{ buildLabel }}</p>
   </div>
+
+  @if (infoOverlay()) {
+    <app-info-sheet [title]="infoTitle()" [body]="infoBody()" (close)="closeInfo()" />
+  }
 </div>

--- a/src/app/features/home/home.ts
+++ b/src/app/features/home/home.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
 import { Router } from '@angular/router';
 import { I18nService } from '../../core/i18n/i18n.service';
 import { AppStateService } from '../../core/state/app-state.service';
@@ -7,13 +7,15 @@ import { buildQuestion, mulberry32, seedFromDate } from '../../core/data/quiz';
 import { computeBadges } from '../../core/data/badges';
 import { AppBar } from '../../shared/app-bar';
 import { Icon } from '../../shared/icon';
+import { InfoSheet } from '../../shared/info-sheet';
 import { LangSwitch } from '../../shared/lang-switch';
-import { StreakPill } from '../../shared/streak-pill';
 import { APP_VERSION, BUILD_CONTEXT, BUILD_SHA } from '../../core/build-info';
+
+type InfoKind = 'streak' | 'accuracy' | 'played' | 'dailyStreak';
 
 @Component({
   selector: 'app-home',
-  imports: [AppBar, Icon, LangSwitch, StreakPill],
+  imports: [AppBar, Icon, InfoSheet, LangSwitch],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './home.html',
   styleUrl: './home.css',
@@ -28,6 +30,59 @@ export class Home {
   /** Versione mostrata in fondo alla home. In dev include "dev" e l'hash di commit. */
   protected readonly buildLabel =
     BUILD_CONTEXT === 'release' ? `v${APP_VERSION}` : `v${APP_VERSION} · dev · ${BUILD_SHA}`;
+
+  /** Quale modale informativa e' aperta in questo momento (null = nessuna). */
+  protected readonly infoOverlay = signal<InfoKind | null>(null);
+
+  protected readonly infoTitle = computed(() => {
+    const isIt = this.i18n.lang() === 'it';
+    switch (this.infoOverlay()) {
+      case 'streak':
+        return isIt ? 'Striscia' : 'Streak';
+      case 'accuracy':
+        return isIt ? 'Precisione' : 'Accuracy';
+      case 'played':
+        return isIt ? 'Partite' : 'Played';
+      case 'dailyStreak':
+        return isIt ? 'Giorni consecutivi' : 'Days in a row';
+      default:
+        return '';
+    }
+  });
+
+  protected readonly infoBody = computed(() => {
+    const isIt = this.i18n.lang() === 'it';
+    const s = this.state();
+    switch (this.infoOverlay()) {
+      case 'streak':
+        return isIt
+          ? `Risposte corrette consecutive in qualunque modalita'. Ricomincia da zero al primo errore. Migliore di sempre: ${s.bestStreak}.`
+          : `Correct answers in a row across any mode. Resets to zero on your first mistake. Personal best: ${s.bestStreak}.`;
+      case 'accuracy':
+        return isIt
+          ? 'Percentuale di risposte corrette sul totale dei caratteri ai quali hai risposto. Si aggiorna a ogni risposta.'
+          : 'Percentage of correct answers over all the characters you have responded to. Updated after every answer.';
+      case 'played':
+        return isIt
+          ? 'Numero totale di caratteri ai quali hai risposto in tutte le modalita\', corretti e sbagliati insieme.'
+          : 'Total number of characters you have answered across all modes, correct and wrong combined.';
+      case 'dailyStreak':
+        return isIt
+          ? `Giorni consecutivi in cui hai concluso la sfida giornaliera. Si azzera se ne salti uno.${s.dailyStreak > 0 ? ` Sei a ${s.dailyStreak}.` : ''}`
+          : `Days in a row you finished the daily challenge. Resets if you skip a day.${s.dailyStreak > 0 ? ` You're on ${s.dailyStreak}.` : ''}`;
+      default:
+        return '';
+    }
+  });
+
+  protected openInfo(kind: InfoKind, e?: Event): void {
+    e?.stopPropagation();
+    this.infoOverlay.set(kind);
+  }
+
+  protected closeInfo(): void {
+    this.infoOverlay.set(null);
+  }
 
   protected readonly todayLabel = computed(() => {
     const locale = this.i18n.lang() === 'it' ? 'it-IT' : 'en-GB';

--- a/src/app/shared/info-sheet.ts
+++ b/src/app/shared/info-sheet.ts
@@ -1,0 +1,55 @@
+import { ChangeDetectionStrategy, Component, HostListener, input, output } from '@angular/core';
+import { Icon } from './icon';
+
+/**
+ * Piccola modale informativa riusabile: titolo + corpo, chiude con X / Esc /
+ * backdrop. Usata in home per spiegare cosa significa ciascun contatore.
+ */
+@Component({
+  selector: 'app-info-sheet',
+  imports: [Icon],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="sheet-backdrop info-backdrop" (click)="close.emit()">
+      <div class="sheet info-sheet" (click)="$event.stopPropagation()">
+        <button class="btn-icon info-close" type="button" (click)="close.emit()" aria-label="Close">
+          <app-icon name="close" />
+        </button>
+        <h2 class="h2 info-title">{{ title() }}</h2>
+        <p class="muted info-body">{{ body() }}</p>
+      </div>
+    </div>
+  `,
+  styles: `
+    .info-backdrop { align-items: center; z-index: 90; }
+    .info-sheet {
+      max-width: 380px;
+      border-radius: 20px;
+      padding: 22px;
+      animation: pop 0.18s ease;
+      position: relative;
+      text-align: left;
+    }
+    .info-close {
+      position: absolute;
+      top: 12px;
+      right: 12px;
+    }
+    .info-title { margin: 0 28px 8px 0; }
+    .info-body {
+      font-size: 14px;
+      line-height: 1.55;
+      margin: 0;
+    }
+  `,
+})
+export class InfoSheet {
+  readonly title = input.required<string>();
+  readonly body = input.required<string>();
+  readonly close = output<void>();
+
+  @HostListener('document:keydown.escape')
+  protected onEsc(): void {
+    this.close.emit();
+  }
+}


### PR DESCRIPTION
Pulizia dell'angolo in alto a destra della home: la pillola con il numero della striscia di gioco e' sparita, perche' era duplicata sotto nella sezione "Le tue statistiche" e creava confusione con la striscia di giorni consecutivi della sfida giornaliera. In alto restano due elementi allineati e leggibili: il selettore di lingua e il pulsante del profilo.

Ogni contatore della home ora si puo' toccare per aprire una piccola scheda di spiegazione: "Striscia" chiarisce che si tratta di risposte corrette consecutive, "Precisione" mostra come viene calcolata, "Partite" indica che conta tutti i caratteri visti. Sulla card della sfida giornaliera, la pillola che prima diceva semplicemente "Streak 3" ora dice "Giorni consecutivi 3": cliccandola si apre la scheda che spiega come funziona la striscia giornaliera.

La card della sfida giornaliera non e' piu' cliccabile per intero: ora solo il pulsante "Gioca" (o "Risultato" se l'hai gia' fatta) avvia/apre la sfida; toccando il badge si apre l'info, non parte piu' il quiz per sbaglio.