### PR TITLE
fix(home): card traguardi a tutta larghezza e anteprima daily piu' chiara

### DIFF
--- a/src/app/features/home/home.css
+++ b/src/app/features/home/home.css
@@ -52,8 +52,12 @@
 }
 
 /* Il container .badges-teaser e i cerchi `.icons > span[data-on][data-t]` sono
-   stylati in styles.css globale, identici al prototipo. Qui solo i piccoli
-   helper di contenuto a sinistra: numero unlocked/totale e label. */
+   stylati in styles.css globale, identici al prototipo. Qui forziamo la
+   larghezza al 100% perche' il button HTML e' inline di default, ed
+   esponiamo gli helper di contenuto a sinistra. */
+.badges-teaser {
+  width: 100%;
+}
 .badges-teaser-meta {
   display: flex;
   flex-direction: column;

--- a/src/app/features/home/home.html
+++ b/src/app/features/home/home.html
@@ -49,13 +49,14 @@
       </h2>
       <p class="muted daily-sub">{{ i18n.t('dailySub') }}</p>
       <div class="daily-row">
-        <div class="glyph-row">
+        <div class="glyph-row" [attr.aria-label]="i18n.lang() === 'it' ? 'Anteprima dei caratteri di oggi' : 'Today preview characters'">
           @if (state().dailyDone) {
             <span>🎯</span>
           } @else {
             @for (g of previewGlyphs(); track $index) {
               <span>{{ g }}</span>
             }
+            <span class="glyph-more" aria-hidden="true">…</span>
           }
         </div>
         <span class="btn btn-primary daily-cta">


### PR DESCRIPTION
Due piccole rifiniture sulla home.

La card "Traguardi" sotto la sezione si estendeva solo per il contenuto, lasciando uno spazio vuoto a destra. Ora occupa tutta la larghezza della pagina, come le card delle modalita' sopra, per un allineamento visivo coerente.

Sulla card della sfida giornaliera, vicino ai tre caratteri di anteprima che sfumano con opacita' decrescente, ora compare un piccolo "..." discreto: era poco chiaro che si trattasse di anteprima di una sequenza piu' lunga. Con i puntini si capisce a colpo d'occhio che dopo i tre caratteri visibili la sfida continua, anche senza dover entrare a giocarla.