### PR TITLE
fix(ui): niente selezione testo e tap highlight su mobile

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -62,6 +62,22 @@ html, body {
   line-height: 1.45;
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
+  /* App-feel: niente selezione del testo accidentale al long-press, niente
+     callout iOS, niente flash celeste al tap su mobile. Eccezioni: testi
+     narrativi (paragrafi) e campi di input restano normalmente selezionabili
+     (vedi regole sotto). */
+  -webkit-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  -webkit-tap-highlight-color: transparent;
+}
+
+p,
+input,
+textarea,
+[contenteditable] {
+  -webkit-user-select: text;
+  user-select: text;
 }
 
 body {


### PR DESCRIPTION
Su mobile bastava tenere premuto un istante in piu' per innescare la selezione del testo o il menu del browser ("Copia, Cerca, Condividi..."), entrambi effetti che spezzavano l'illusione che l'app fosse nativa. Stessa cosa per il rettangolo celeste che lampeggia su Chrome Mobile quando si tocca un pulsante. Tutti questi default vengono ora disattivati a livello globale.

Restano normalmente selezionabili e cliccabili come ci si aspetta: i paragrafi di testo narrativo (descrizioni, blurb, spiegazioni dei traguardi), gli eventuali campi di input e qualunque area editabile. Quindi un utente che vuole copiare la descrizione di una scrittura puo' farlo, mentre un long-press sul glifo del quiz non interrompe piu' il gioco.