### PR TITLE
fix(onboarding): ripristina decoratore @Component (build rotta)

### DIFF
--- a/src/app/features/onboarding/onboarding.ts
+++ b/src/app/features/onboarding/onboarding.ts
@@ -34,6 +34,9 @@ const STEPS: ReadonlyArray<OnboardingStep> = [
   },
 ];
 
+const SWIPE_THRESHOLD = 50;
+const SWIPE_MAX_OFFAXIS = 60;
+
 @Component({
   selector: 'app-onboarding',
   imports: [Icon, LangSwitch, Logo],
@@ -41,9 +44,6 @@ const STEPS: ReadonlyArray<OnboardingStep> = [
   templateUrl: './onboarding.html',
   styleUrl: './onboarding.css',
 })
-const SWIPE_THRESHOLD = 50;
-const SWIPE_MAX_OFFAXIS = 60;
-
 export class Onboarding {
   protected readonly i18n = inject(I18nService);
   private readonly appState = inject(AppStateService);


### PR DESCRIPTION
Una regressione introdotta dalla PR sullo swipe mobile faceva fallire la build: le due costanti per la soglia di scorrimento erano finite per errore in mezzo, fra il decoratore @Component e la classe Onboarding, e TypeScript leggeva il decoratore come applicato alle costanti invece che alla classe. Risultato: l'onboarding non veniva piu' riconosciuto come componente Angular e l'intera app non compilava.

Spostate le due costanti prima del decoratore, la build torna verde. Comportamento utente invariato, lo swipe mobile continua a funzionare come previsto.

Da mergiare prima della Release PR 1.1.0, altrimenti il deploy in produzione fallisce.