### PR TITLE
fix(ui): rifiniture allineamento e spaziatura su home, lang switch e badges

### DIFF
--- a/src/app/features/badges/badges.css
+++ b/src/app/features/badges/badges.css
@@ -86,9 +86,23 @@
   right: 12px;
 }
 
+/* Sheet dettaglio traguardo: hero stacked (icona sopra, status sotto, tutto
+   centrato), titolo e descrizione centrati, card "come sbloccarlo" allineata
+   a sinistra, barra di progresso con etichetta sotto. */
+.badge-sheet-hero {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  margin: 6px 0 14px;
+}
+/* Override del global .badge-icon-lg che e' inline-grid: nel contesto della
+   sheet vogliamo che si comporti da block-level dentro la colonna. */
+.badge-sheet-hero .badge-icon-lg {
+  display: grid;
+  margin: 0;
+}
 .badge-sheet-status {
-  display: inline-block;
-  margin: 14px 0 6px;
   color: var(--text-mute);
 }
 .badge-sheet-status.unlocked {
@@ -96,12 +110,13 @@
 }
 
 .badge-sheet-title {
-  margin: 0;
+  margin: 0 0 6px;
 }
 
 .badge-sheet-desc {
-  margin: 6px 0 18px;
+  margin: 0 0 18px;
   font-size: 14px;
+  line-height: 1.55;
 }
 
 .badge-sheet-quest {
@@ -109,19 +124,20 @@
   background: var(--surface-2);
   border: 1px solid var(--border);
   border-radius: 12px;
-  padding: 12px 14px;
-  margin-bottom: 16px;
+  padding: 14px 16px;
+  margin-bottom: 22px;
 }
 .badge-sheet-quest p {
-  margin: 6px 0 0;
+  margin: 8px 0 0;
   font-size: 13px;
+  line-height: 1.5;
   color: var(--text);
 }
 
 .badge-sheet-progress {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 8px;
 }
 .badge-bar {
   position: relative;

--- a/src/app/features/badges/badges.html
+++ b/src/app/features/badges/badges.html
@@ -41,15 +41,17 @@
           <app-icon name="close" />
         </button>
 
-        <div class="badge-icon-lg" [attr.data-unlocked]="d.unlocked ? '1' : '0'" [attr.data-tier]="d.tier">
-          {{ d.icon }}
+        <div class="badge-sheet-hero">
+          <div class="badge-icon-lg" [attr.data-unlocked]="d.unlocked ? '1' : '0'" [attr.data-tier]="d.tier">
+            {{ d.icon }}
+          </div>
+          <span class="eyebrow badge-sheet-status" [class.unlocked]="d.unlocked">
+            {{ d.unlocked
+              ? (i18n.lang() === 'it' ? 'SBLOCCATO' : 'UNLOCKED')
+              : (i18n.lang() === 'it' ? 'DA SBLOCCARE' : 'TO UNLOCK') }}
+            · {{ d.tier.toUpperCase() }}
+          </span>
         </div>
-        <span class="eyebrow badge-sheet-status" [class.unlocked]="d.unlocked">
-          {{ d.unlocked
-            ? (i18n.lang() === 'it' ? 'SBLOCCATO' : 'UNLOCKED')
-            : (i18n.lang() === 'it' ? 'DA SBLOCCARE' : 'TO UNLOCK') }}
-          · {{ d.tier.toUpperCase() }}
-        </span>
         <h2 class="h2 badge-sheet-title">{{ titleOf(d) }}</h2>
         <p class="muted badge-sheet-desc">{{ descOf(d) }}</p>
 

--- a/src/app/features/home/home.css
+++ b/src/app/features/home/home.css
@@ -75,34 +75,42 @@
 
 /* Il container .badges-teaser e i cerchi `.icons > span[data-on][data-t]` sono
    stylati in styles.css globale, identici al prototipo. Qui forziamo la
-   larghezza al 100% perche' il button HTML e' inline di default, ed
-   esponiamo gli helper di contenuto a sinistra. */
+   larghezza al 100% (il button HTML e' inline di default), riduciamo
+   leggermente il padding verticale e mettiamo numero / totale / label tutto
+   su una riga sola, centrata verticalmente. */
 .badges-teaser {
   width: 100%;
+  padding-top: 10px;
+  padding-bottom: 10px;
 }
 .badges-teaser-meta {
   display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
-.badges-teaser-count {
-  display: flex;
   align-items: baseline;
-  gap: 6px;
+  gap: 4px;
+  line-height: 1;
 }
-.badges-teaser-count .v {
+.badges-teaser-meta .v {
   font-family: var(--font-display);
   font-weight: 700;
   font-size: 22px;
   color: var(--accent);
-  line-height: 1;
 }
-.badges-teaser-count .l {
+.badges-teaser-meta .l {
   font-size: 13px;
   color: var(--text-dim);
 }
 .badges-teaser-label {
   font-size: 12px;
+  margin-left: 6px;
+}
+
+/* Le icone di modalita' (emoji ∞ / ⏱ / ♥) restano centrate nel quadratino
+   38x38: passiamo al font di display + line-height 1 per evitare la baseline
+   del mono che le fa scendere fuori asse. */
+.mode-card .icon {
+  font-family: var(--font-display), 'Apple Color Emoji', 'Segoe UI Emoji', system-ui;
+  font-size: 20px;
+  line-height: 1;
 }
 
 .home-foot {

--- a/src/app/features/home/home.html
+++ b/src/app/features/home/home.html
@@ -33,9 +33,7 @@
         } @else {
           <button type="button" class="pill warm daily-status" (click)="openInfo('dailyStreak', $event)">
             <span class="dot"></span>
-            <span>
-              {{ i18n.lang() === 'it' ? 'Giorni consecutivi' : 'Days in a row' }} {{ state().dailyStreak }}
-            </span>
+            <span>{{ state().dailyStreak }} {{ i18n.lang() === 'it' ? 'giorni' : 'days' }}</span>
           </button>
         }
       </div>
@@ -152,13 +150,9 @@
     </div>
     <button class="badges-teaser" type="button" (click)="goBadges()">
       <div class="badges-teaser-meta">
-        <div class="badges-teaser-count">
-          <span class="v">{{ badgeStats().unlocked }}</span>
-          <span class="l">/ {{ badgeStats().total }}</span>
-        </div>
-        <div class="muted badges-teaser-label">
-          {{ i18n.lang() === 'it' ? 'sbloccati' : 'unlocked' }}
-        </div>
+        <span class="v">{{ badgeStats().unlocked }}</span>
+        <span class="l">/ {{ badgeStats().total }}</span>
+        <span class="muted badges-teaser-label">{{ i18n.lang() === 'it' ? 'sbloccati' : 'unlocked' }}</span>
       </div>
       <div class="icons">
         @for (b of badgeStats().preview; track b.id) {

--- a/src/app/shared/lang-switch.ts
+++ b/src/app/shared/lang-switch.ts
@@ -40,6 +40,7 @@ interface LangOption {
     .lang-code-display {
       font-family: var(--font-mono);
       font-size: 12px;
+      line-height: 1;
       color: var(--text-dim);
       transition: color var(--hover-dur) ease;
     }
@@ -47,15 +48,20 @@ interface LangOption {
     .lang-switch.is-open .lang-code-display { color: var(--text); }
 
     /* Chevron rivolta in basso a riposo, ruota a "in alto" quando il
-       dropdown e' aperto. transform anziche' rotation iteration cosi'
-       l'animazione resta legata allo stato. */
+       dropdown e' aperto. inline-flex + align/justify center fanno sì che
+       l'SVG sia centrato nel proprio box e la rotazione avvenga intorno al
+       centro effettivo (non al baseline del testo accanto). */
     .lang-chev {
       display: inline-flex;
-      width: 12px;
-      height: 12px;
+      align-items: center;
+      justify-content: center;
+      width: 14px;
+      height: 14px;
       transform: rotate(90deg);
+      transform-origin: center center;
       transition: transform 180ms var(--tx-ease);
     }
+    .lang-chev svg { width: 14px; height: 14px; display: block; }
     .lang-switch.is-open .lang-chev { transform: rotate(-90deg); }
     [data-motion='minimal'] .lang-chev { transition: none; }
     .lang-pop {


### PR DESCRIPTION
Cinque piccole correzioni viste in giro sull'app, tutte di "allineamento e spaziatura".

La freccia del selettore di lingua in alto a destra della home non era piu' centrata verticalmente con il codice "IT"/"EN" accanto, e ruotava intorno a un punto sbagliato: ora il chevron e' centrato nel suo box e la rotazione avviene in modo simmetrico.

Sulla card della sfida giornaliera, la pillola "Giorni consecutivi 3" / "Days in a row 3" era troppo lunga e usciva dall'allineamento. Adesso e' compatta: "3 giorni" in italiano, "3 days" in inglese.

Le icone dentro le card delle modalita' di gioco (∞ per Allenamento, ⏱ per A tempo, ♥ per Survival) cadevano un po' fuori dal loro quadratino: passate al font del testo principale con line-height stretta, ora sono perfettamente centrate.

Nella card riassuntiva dei traguardi sulla home, il contatore "1 / 10 sbloccati" era spezzato su due righe e disallineato verticalmente. Ora tutto su una riga, baseline allineata, padding verticale piu' contenuto.

Nella scheda di dettaglio del singolo traguardo, l'icona grande appariva a sinistra del testo "DA SBLOCCARE · BRONZE" invece che sopra. Sistemato il layout in colonna: icona al centro, sotto la riga di stato, sotto il titolo e cosi' via. Aumentato il padding del riquadro "Come sbloccarlo" e lo spazio tra le sezioni per dare aria al contenuto.