### PR TITLE
feat(game): polish degli indicatori di gameplay

### DIFF
--- a/src/app/features/game/game.css
+++ b/src/app/features/game/game.css
@@ -176,3 +176,19 @@
   text-align: left;
   margin-top: 14px;
 }
+
+/* Indicatori del meta-counter sopra il glifo */
+.meta-pct {
+  color: var(--text-dim);
+  margin-left: 2px;
+}
+
+/* Le opzioni eliminate dal "Hint" non hanno piu' la barra-cancella sul testo:
+   diventano solo un filo piu' tenui dello stato originale, niente piu' tratto
+   che attraversa il nome — era difficile riconoscere quale fosse stata
+   rimossa. Il pulsante resta non cliccabile (gestione lato componente). */
+.opt[data-state='dim'] {
+  text-decoration: none;
+  opacity: 0.25;
+  pointer-events: none;
+}

--- a/src/app/features/game/game.html
+++ b/src/app/features/game/game.html
@@ -8,9 +8,11 @@
       <app-icon name="close" />
     </button>
     <div class="progress-wrap">
-      <div class="progress">
-        <i [style.width.%]="totalProgress() * 100"></i>
-      </div>
+      @if (hasProgress()) {
+        <div class="progress">
+          <i [style.width.%]="totalProgress() * 100"></i>
+        </div>
+      }
     </div>
     <div class="gamebar-r">
       @if (isTimed()) {
@@ -29,6 +31,9 @@
         @switch (mode()) {
           @case ('daily') {
             <span>{{ i18n.lang() === 'it' ? 'Sfida' : 'Daily' }} · {{ idx() + 1 }}/{{ totalDaily }}</span>
+            @if (history().length > 0) {
+              <span class="meta-pct"> ({{ accuracyPct() }}%)</span>
+            }
           }
           @case ('timed') {
             <span>{{ i18n.t('timed') }} · </span>
@@ -39,12 +44,18 @@
           }
           @case ('survival') {
             <span>Survival · {{ correctCount() }}</span>
+            @if (history().length > 0) {
+              <span class="meta-pct"> ({{ accuracyPct() }}%)</span>
+            }
           }
           @default {
             @if (weakOnly()) {
               <span>{{ i18n.t('weak') }} · {{ correctCount() }}/{{ history().length }}</span>
             } @else {
               <span>{{ i18n.t('training') }} · {{ correctCount() }}/{{ history().length }}</span>
+            }
+            @if (history().length > 0) {
+              <span class="meta-pct"> ({{ accuracyPct() }}%)</span>
             }
           }
         }

--- a/src/app/features/game/game.ts
+++ b/src/app/features/game/game.ts
@@ -109,11 +109,33 @@ export class Game implements OnDestroy {
 
   protected readonly totalDaily = DAILY_TOTAL;
   protected readonly correctCount = computed(() => this.history().filter((h) => h.correct).length);
+
+  /**
+   * Avanzamento mostrato dalla progress bar in alto:
+   * - daily: quante delle 5 carte hai gia' visto (cresce 0→1)
+   * - timed: quanto tempo ti resta, NON quanto ne hai usato (parte piena, decresce 1→0)
+   * - survival: quante vite ti restano (parte piena, decresce 1→0)
+   * - training (default): non c'e' un totale, la barra viene nascosta nel template
+   */
   protected readonly totalProgress = computed(() => {
     if (this.isDaily()) return this.idx() / DAILY_TOTAL;
-    if (this.isTimed()) return (TIMED_DURATION - this.secondsLeft()) / TIMED_DURATION;
-    return Math.min(this.history().length / 20, 1);
+    if (this.isTimed()) return this.secondsLeft() / TIMED_DURATION;
+    if (this.isSurvival()) return this.lives() / SURVIVAL_LIVES;
+    return 0;
   });
+
+  /** Vero quando ha senso mostrare la barra di progresso; in training no. */
+  protected readonly hasProgress = computed(
+    () => this.isDaily() || this.isTimed() || this.isSurvival(),
+  );
+
+  /** Percentuale di risposte corrette finora, intera (0..100). 0 se ancora nulla. */
+  protected readonly accuracyPct = computed(() => {
+    const total = this.history().length;
+    if (total === 0) return 0;
+    return Math.round((100 * this.correctCount()) / total);
+  });
+
   protected readonly showCp = computed(() => this.state().showCodepoint);
 
   private timerId: ReturnType<typeof setInterval> | null = null;

--- a/src/app/features/onboarding/onboarding.ts
+++ b/src/app/features/onboarding/onboarding.ts
@@ -34,6 +34,9 @@ const STEPS: ReadonlyArray<OnboardingStep> = [
   },
 ];
 
+const SWIPE_THRESHOLD = 50;
+const SWIPE_MAX_OFFAXIS = 60;
+
 @Component({
   selector: 'app-onboarding',
   imports: [Icon, LangSwitch, Logo],
@@ -41,9 +44,6 @@ const STEPS: ReadonlyArray<OnboardingStep> = [
   templateUrl: './onboarding.html',
   styleUrl: './onboarding.css',
 })
-const SWIPE_THRESHOLD = 50;
-const SWIPE_MAX_OFFAXIS = 60;
-
 export class Onboarding {
   protected readonly i18n = inject(I18nService);
   private readonly appState = inject(AppStateService);


### PR DESCRIPTION
Cinque ritocchi all'esperienza del quiz.

Quando attivi l'aiuto (lampadina) che elimina due opzioni sbagliate, prima quelle opzioni venivano sbarrate con una linea: era poco chiaro quale fosse stata "tolta". Ora si limitano a perdere quasi tutto il colore (rimangono come ombre sullo sfondo) e non rispondono al tocco.

In modalita' "Allenamento libero" non c'e' un totale di domande, quindi la barra di progresso in alto non aveva senso. Ora in allenamento la barra sparisce del tutto.

In modalita' "Sfida a tempo" la barra di progresso ora parte piena e si svuota man mano che il tempo scorre (prima era al contrario, cresceva con il tempo passato).

In modalita' Survival la barra rappresenta le vite residue: parte piena e cala a ogni cuore perso.

Accanto al contatore "X / Y" delle modalita' Allenamento, Survival e Sfida giornaliera ora compare la percentuale di risposte corrette finora, per avere un riscontro immediato della prestazione.