### PR TITLE
fix(chrome): pulsanti app-bar centrati + transizione moderna fra schermate

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,5 +1,5 @@
 import { ApplicationConfig, provideBrowserGlobalErrorListeners, provideZonelessChangeDetection } from '@angular/core';
-import { provideRouter, withInMemoryScrolling } from '@angular/router';
+import { provideRouter, withInMemoryScrolling, withViewTransitions } from '@angular/router';
 
 import { routes } from './app.routes';
 
@@ -10,6 +10,10 @@ export const appConfig: ApplicationConfig = {
     provideRouter(
       routes,
       withInMemoryScrolling({ scrollPositionRestoration: 'top', anchorScrolling: 'enabled' }),
+      // Transizioni di route con la View Transitions API nativa del browser
+      // (Chrome/Edge moderni). Crossfade morbido tra schermate; sui browser che
+      // non supportano la API il cambio resta istantaneo, niente di rotto.
+      withViewTransitions(),
     ),
   ],
 };

--- a/src/app/features/onboarding/onboarding.ts
+++ b/src/app/features/onboarding/onboarding.ts
@@ -34,6 +34,9 @@ const STEPS: ReadonlyArray<OnboardingStep> = [
   },
 ];
 
+const SWIPE_THRESHOLD = 50;
+const SWIPE_MAX_OFFAXIS = 60;
+
 @Component({
   selector: 'app-onboarding',
   imports: [Icon, LangSwitch, Logo],
@@ -41,9 +44,6 @@ const STEPS: ReadonlyArray<OnboardingStep> = [
   templateUrl: './onboarding.html',
   styleUrl: './onboarding.css',
 })
-const SWIPE_THRESHOLD = 50;
-const SWIPE_MAX_OFFAXIS = 60;
-
 export class Onboarding {
   protected readonly i18n = inject(I18nService);
   private readonly appState = inject(AppStateService);

--- a/src/app/shared/icon.ts
+++ b/src/app/shared/icon.ts
@@ -16,6 +16,12 @@ export type IconName =
 @Component({
   selector: 'app-icon',
   changeDetection: ChangeDetectionStrategy.OnPush,
+  // L'host element diventa inline-flex centrato: cosi' l'SVG e' sempre
+  // perfettamente allineato col testo accanto in container come .nav-btn,
+  // .pill, .btn senza dover ripetere align-items in ogni dichiarazione.
+  host: {
+    style: 'display: inline-flex; align-items: center; justify-content: center; line-height: 0;',
+  },
   template: `
     @switch (name()) {
       @case ('chev') {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1276,3 +1276,28 @@ button {
   letter-spacing: .04em;
   animation: quiet-in 200ms ease;
 }
+
+/* ── Route transitions (View Transitions API) ───────────────────────
+   Crossfade con un accenno di slide orizzontale al cambio route.
+   Solo browser che supportano `document.startViewTransition` (Chrome,
+   Edge moderni): gli altri vedono il cambio istantaneo, niente di rotto.
+   In modalita' animazioni "minimal" la transizione e' istantanea. */
+@view-transition { navigation: auto; }
+::view-transition-old(root) {
+  animation: tx-route-out 220ms var(--tx-ease) forwards;
+}
+::view-transition-new(root) {
+  animation: tx-route-in 220ms var(--tx-ease) forwards;
+}
+@keyframes tx-route-out {
+  to { opacity: 0; transform: translateX(-6%); }
+}
+@keyframes tx-route-in {
+  from { opacity: 0; transform: translateX(6%); }
+  to { opacity: 1; transform: translateX(0); }
+}
+[data-motion='minimal'] ::view-transition-old(root),
+[data-motion='minimal'] ::view-transition-new(root) {
+  animation-duration: 0ms;
+}
+


### PR DESCRIPTION
Pulsanti "Indietro" e "Home" nella barra in alto: l'icona non era allineata verticalmente col testo accanto o col bordo del pulsante. Aggiunto al componente icona un host display in flex centrato e line-height zero, cosi' l'SVG e' sempre perfettamente al centro del proprio box in ogni contesto (anche dentro pillole, mode-card e altri pulsanti).

Aggiunta una transizione morbida fra schermate quando navighi avanti e indietro: piccolo crossfade con un accenno di slide laterale. Funziona su Chrome ed Edge moderni; negli altri browser il cambio resta istantaneo. Se hai impostato "Minimo" come livello di animazioni nelle impostazioni, anche questa viene disattivata.