### PR TITLE
feat(home): streak in evidenza + icona daily + selezione vuota di default

### DIFF
--- a/src/app/core/state/types.ts
+++ b/src/app/core/state/types.ts
@@ -58,7 +58,10 @@ export interface AppState {
 
 export const DEFAULT_STATE: AppState = {
   onboarded: false,
-  selected: ['hiragana', 'hangul', 'devanagari', 'arabic', 'thai', 'greek'],
+  // Nessuna scrittura selezionata di default: la prima volta che l'utente entra
+  // in "Scegli le scritture" deve compiere una scelta esplicita. La sua scelta
+  // viene poi memorizzata in localStorage e riproposta nelle sessioni seguenti.
+  selected: [],
   streak: 0,
   bestStreak: 0,
   played: 0,

--- a/src/app/features/home/home.css
+++ b/src/app/features/home/home.css
@@ -9,6 +9,28 @@
   color: var(--accent);
 }
 
+/* Pillola "streak di gioco" in evidenza sotto al saluto. Compare solo se
+   l'utente ha una serie attiva (>0): se 0 la nascondiamo per non mostrare
+   "0 di fila" che fa peggio del nulla. Cliccabile per aprire la modale info. */
+.home-streak {
+  align-self: flex-start;
+  margin-top: 10px;
+  cursor: pointer;
+  font: inherit;
+  gap: 6px;
+  height: 30px;
+  padding: 0 12px;
+}
+.home-streak-value {
+  font-weight: 700;
+  color: var(--warm);
+}
+.home-streak-label {
+  color: var(--warm);
+  opacity: 0.85;
+}
+.home-streak:hover { filter: brightness(1.1); }
+
 .daily-head {
   display: flex;
   justify-content: space-between;

--- a/src/app/features/home/home.html
+++ b/src/app/features/home/home.html
@@ -20,6 +20,13 @@
           {{ i18n.lang() === 'it' ? 'Ciao,' : 'Hi,' }} <span class="home-name">{{ i18n.lang() === 'it' ? 'lettore.' : 'reader.' }}</span>
         }
       </h1>
+      @if (state().streak > 0) {
+        <button type="button" class="pill warm home-streak" (click)="openInfo('streak', $event)">
+          <app-icon name="flame" />
+          <span class="home-streak-value tabnum">{{ state().streak }}</span>
+          <span class="home-streak-label">{{ i18n.lang() === 'it' ? 'di fila' : 'in a row' }}</span>
+        </button>
+      }
     </div>
 
     <div class="daily">
@@ -32,8 +39,8 @@
           </button>
         } @else {
           <button type="button" class="pill warm daily-status" (click)="openInfo('dailyStreak', $event)">
-            <span class="dot"></span>
-            <span>{{ state().dailyStreak }} {{ i18n.lang() === 'it' ? 'giorni' : 'days' }}</span>
+            <app-icon name="calendar" />
+            <span class="tabnum">{{ state().dailyStreak }}</span>
           </button>
         }
       </div>

--- a/src/app/shared/icon.ts
+++ b/src/app/shared/icon.ts
@@ -11,7 +11,8 @@ export type IconName =
   | 'check'
   | 'bolt'
   | 'share'
-  | 'arrow-right';
+  | 'arrow-right'
+  | 'calendar';
 
 @Component({
   selector: 'app-icon',
@@ -56,6 +57,9 @@ export type IconName =
       }
       @case ('arrow-right') {
         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="M13 5l7 7-7 7"/></svg>
+      }
+      @case ('calendar') {
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="16" rx="2"/><path d="M3 9h18"/><path d="M8 3v4M16 3v4"/></svg>
       }
     }
   `,


### PR DESCRIPTION
Tre cambiamenti coordinati sulla home.

Sotto al saluto "Ciao, lettore." compare ora una piccola pillola ambra con la fiamma: e' la tua striscia di risposte corrette in corso (es. "🔥 5 di fila"). E' visibile solo se hai gia' una striscia attiva: appena la perdi al primo errore la pillola sparisce silenziosamente per non distrarti. Cliccandola si apre la modale che spiega cos'e' la striscia.

Sulla card della sfida giornaliera, la pillola che prima diceva "Giorni consecutivi 3" e' diventata una piccola icona calendario seguita dal numero. Compatta e immediata. Cliccando si apre la spiegazione, come prima.

La prima volta che apri la schermata "Scegli le scritture" trovi tutte le scritture deselezionate, cosi' fai una scelta personale invece di partire dai sei default. La tua scelta viene poi memorizzata e riproposta automaticamente nelle sessioni successive.