### PR TITLE
fix(game): rende riconoscibili le opzioni escluse dall'Hint

### DIFF
--- a/src/app/features/game/game.css
+++ b/src/app/features/game/game.css
@@ -183,12 +183,36 @@
   margin-left: 2px;
 }
 
-/* Le opzioni eliminate dal "Hint" non hanno piu' la barra-cancella sul testo:
-   diventano solo un filo piu' tenui dello stato originale, niente piu' tratto
-   che attraversa il nome — era difficile riconoscere quale fosse stata
-   rimossa. Il pulsante resta non cliccabile (gestione lato componente). */
+/* Opzioni eliminate dall'Hint: devono restare riconoscibili a colpo d'occhio
+   come "escluse" senza la barra-cancella sul testo (che si confondeva).
+   Sfondo piu' scuro, bordo tratteggiato, testo tenue, e il numero della
+   scorciatoia (1/2/3/4) viene sostituito da una piccola croce. Non cliccabili. */
 .opt[data-state='dim'] {
   text-decoration: none;
-  opacity: 0.25;
+  opacity: 0.7;
   pointer-events: none;
+  background: var(--surface-2);
+  border-style: dashed;
+  border-color: var(--border-strong);
+  color: var(--text-mute);
+}
+.opt[data-state='dim'] .opt-key {
+  background: transparent;
+  border-color: var(--border-strong);
+  color: transparent;
+  position: relative;
+}
+.opt[data-state='dim'] .opt-key::after {
+  content: '✕';
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  font-family: var(--font-display);
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text-mute);
+}
+.opt[data-state='dim'] .opt-tag {
+  opacity: 0.4;
 }


### PR DESCRIPTION
L'aiuto (lampadina) elimina due opzioni sbagliate, ma erano semplicemente piu' tenui: difficile capire quali fossero state messe da parte. Ora le opzioni escluse hanno un aspetto evidentemente diverso da quelle ancora giocabili: sfondo piu' scuro, bordo tratteggiato, testo grigio, e al posto del numero della scorciatoia (1/2/3/4) compare una piccola croce. A colpo d'occhio capisci dove si concentrano le due risposte rimaste valide.