### PR TITLE
fix(home): riduce la dimensione del contatore traguardi sulla card

### DIFF
--- a/src/app/features/home/home.css
+++ b/src/app/features/home/home.css
@@ -114,7 +114,7 @@
 .badges-teaser-meta .v {
   font-family: var(--font-display);
   font-weight: 700;
-  font-size: 22px;
+  font-size: 17px;
   color: var(--accent);
 }
 .badges-teaser-meta .l {


### PR DESCRIPTION
Nella card riassuntiva dei traguardi sulla home, il numero ambra ("0" o quanti ne hai sbloccati) era visivamente troppo grande del resto della card e ne squilibrava il bilanciamento ottico. Portato da 22px a 17px, in linea con gli altri titoli intermedi della pagina; mantiene il peso bold cosi' resta distinguibile a colpo d'occhio.