### PR TITLE
fix(seo): nel sitemap solo la URL della home

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,38 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <!--
+    Il sito e' una SPA Angular con path location: solo la URL della root e'
+    servita da Pages come file fisico (index.html). Tutte le altre route
+    (/home, /selection, /daily, ecc.) sono client-side, e quando Google
+    le crawla direttamente trova il 404.html di fallback con meta noindex.
+    Listing una sola URL evita di sporcare il rapporto di Search Console
+    con "Pagine con redirect" per le sub-route. Google bot moderno esegue
+    JavaScript e raggiunge da solo le altre schermate dalla home.
+  -->
   <url>
     <loc>https://alessiopesit-boop.github.io/guess-the-char/</loc>
-    <changefreq>monthly</changefreq>
+    <changefreq>weekly</changefreq>
     <priority>1.0</priority>
-  </url>
-  <url>
-    <loc>https://alessiopesit-boop.github.io/guess-the-char/home</loc>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-  <url>
-    <loc>https://alessiopesit-boop.github.io/guess-the-char/onboarding</loc>
-    <changefreq>yearly</changefreq>
-    <priority>0.3</priority>
-  </url>
-  <url>
-    <loc>https://alessiopesit-boop.github.io/guess-the-char/selection</loc>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://alessiopesit-boop.github.io/guess-the-char/daily</loc>
-    <changefreq>daily</changefreq>
-    <priority>0.9</priority>
-  </url>
-  <url>
-    <loc>https://alessiopesit-boop.github.io/guess-the-char/badges</loc>
-    <changefreq>monthly</changefreq>
-    <priority>0.5</priority>
-  </url>
-  <url>
-    <loc>https://alessiopesit-boop.github.io/guess-the-char/settings</loc>
-    <changefreq>yearly</changefreq>
-    <priority>0.2</priority>
   </url>
 </urlset>


### PR DESCRIPTION
Il sitemap elencava sette URL (la home + sei sub-route come /home, /selection, /daily, ecc.) ma su GitHub Pages solo la root e' un file fisico: le altre route vivono nel routing Angular client-side, e quando Google le crawla direttamente trova il 404.html del fallback SPA (con meta noindex). Risultato: Search Console le avrebbe segnalate come "Pagine con redirect" o "Escluse da noindex", sporcando i rapporti senza dare valore.

Tenuta solo la URL della home, l'unica realmente servita come HTML. Google bot moderno esegue JavaScript e dalla home raggiunge da solo tutte le altre schermate cliccando i link.

Dopo il merge: reinvia il sitemap da Search Console (stesso URL, "sitemap.xml"), si aggiorna senza side-effect.