### PR TITLE
fix(ui): typo Modalita, spiegazione livello animazioni e contatore traguardo

### DIFF
--- a/src/app/features/badges/badges.css
+++ b/src/app/features/badges/badges.css
@@ -154,6 +154,7 @@
 }
 .badge-bar-label {
   display: flex;
-  justify-content: space-between;
+  justify-content: center;
+  gap: 4px;
   font-size: 12px;
 }

--- a/src/app/features/home/home.html
+++ b/src/app/features/home/home.html
@@ -73,7 +73,7 @@
     </div>
 
     <div class="section-head">
-      <h3 class="h3">{{ i18n.lang() === 'it' ? 'Modalita' : 'Game modes' }}</h3>
+      <h3 class="h3">{{ i18n.lang() === 'it' ? 'Modalita’' : 'Game modes' }}</h3>
     </div>
     <div class="mode-list">
       <button class="mode-card" type="button" (click)="goSelection('training')">

--- a/src/app/features/settings/settings.css
+++ b/src/app/features/settings/settings.css
@@ -135,3 +135,10 @@
 .reset-btn:hover {
   background: rgba(251, 113, 133, 0.08);
 }
+
+/* Spiegazione del livello di animazioni attivo: cambia in base alla scelta corrente. */
+.motion-hint {
+  font-size: 12px;
+  line-height: 1.5;
+  margin: 6px 2px 0;
+}

--- a/src/app/features/settings/settings.html
+++ b/src/app/features/settings/settings.html
@@ -42,6 +42,7 @@
           </button>
         }
       </div>
+      <p class="muted motion-hint">{{ motionHint(state().motion) }}</p>
     </section>
 
     <section class="settings-section">

--- a/src/app/features/settings/settings.ts
+++ b/src/app/features/settings/settings.ts
@@ -77,6 +77,17 @@ export class Settings {
     if (isIt) return m === 'minimal' ? 'Minimo' : m === 'playful' ? 'Giocoso' : 'Ricco';
     return m === 'minimal' ? 'Minimal' : m === 'playful' ? 'Playful' : 'Rich';
   }
+  protected motionHint(m: MotionLevel): string {
+    const isIt = this.i18n.lang() === 'it';
+    if (isIt) {
+      if (m === 'minimal') return 'Quasi nessuna animazione: schermate e pulsanti rispondono in modo istantaneo.';
+      if (m === 'playful') return 'Transizioni morbide tra le schermate e feedback animati sui glifi.';
+      return 'Tutte le animazioni attive, inclusi micro-effetti su pulsanti, glifi e transizioni.';
+    }
+    if (m === 'minimal') return 'Almost no animation: screens and buttons respond instantly.';
+    if (m === 'playful') return 'Smooth screen transitions and animated feedback on glyphs.';
+    return 'All animations on, including micro-effects on buttons, glyphs and transitions.';
+  }
   protected cbLabel(m: ColorblindMode): string {
     const isIt = this.i18n.lang() === 'it';
     if (isIt) return m === 'none' ? 'Standard' : m === 'redgreen' ? 'Rosso e verde' : 'Blu e giallo';


### PR DESCRIPTION
In home il titolo della sezione era "Modalita" senza apostrofo, ora "Modalita'" come dovrebbe essere.

In impostazioni, sotto i tre livelli di animazione (Minimo / Giocoso / Ricco), appare una riga di descrizione che spiega in una frase cosa cambia con il livello attualmente attivo, cosi' la scelta diventa comprensibile senza doverla testare.

Aprendo la scheda di un traguardo, il contatore in fondo (es. "0 / 5") era sparpagliato ai due estremi della barra di progresso. Ora i due numeri stanno fianco a fianco al centro, piu' leggibili a colpo d'occhio.