### PR TITLE
feat(chrome): direzione delle transizioni di schermata coerente con avanti/indietro

### DIFF
--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component, effect, inject } from '@angular/core';
 import { Title } from '@angular/platform-browser';
-import { RouterOutlet } from '@angular/router';
+import { NavigationStart, Router, RouterOutlet } from '@angular/router';
 import { AppStateService } from './core/state/app-state.service';
 import { ACCENT_PALETTES } from './core/state/types';
 import { BUILD_CONTEXT } from './core/build-info';
@@ -15,8 +15,21 @@ import { BUILD_CONTEXT } from './core/build-info';
 export class App {
   private readonly appState = inject(AppStateService);
   private readonly title = inject(Title);
+  private readonly router = inject(Router);
 
   constructor() {
+    // Direzione della navigazione corrente, usata dal CSS delle view transitions:
+    // se l'utente ha premuto Indietro (browser o app), e' 'back' e il CSS inverte
+    // l'asse dello slide; in tutti gli altri casi (link, push imperativo) e' 'forward'.
+    // Settiamo l'attributo SINCRONO su NavigationStart, prima che withViewTransitions
+    // catturi lo snapshot.
+    this.router.events.subscribe((e) => {
+      if (e instanceof NavigationStart) {
+        const dir = e.navigationTrigger === 'popstate' ? 'back' : 'forward';
+        document.documentElement.setAttribute('data-nav-direction', dir);
+      }
+    });
+
     // In sviluppo, prefissa il nome della scheda con "[dev] " per distinguere a
     // colpo d'occhio le build locali da quelle pubblicate. In production il
     // file fileReplaced ha BUILD_CONTEXT='release' e il title resta com'e'.

--- a/src/styles.css
+++ b/src/styles.css
@@ -1279,21 +1279,39 @@ button {
 
 /* ── Route transitions (View Transitions API) ───────────────────────
    Crossfade con un accenno di slide orizzontale al cambio route.
+   Direzione dinamica: il root <html> riceve data-nav-direction="forward"
+   o "back" da app.ts in base al navigationTrigger del Router (popstate =
+   indietro). Forward: la vecchia esce verso sinistra, la nuova entra da
+   destra. Back: invertiamo l'asse cosi' il movimento e' coerente con il
+   tasto Indietro del browser e con i pulsanti back nell'AppBar.
    Solo browser che supportano `document.startViewTransition` (Chrome,
    Edge moderni): gli altri vedono il cambio istantaneo, niente di rotto.
    In modalita' animazioni "minimal" la transizione e' istantanea. */
 @view-transition { navigation: auto; }
 ::view-transition-old(root) {
-  animation: tx-route-out 220ms var(--tx-ease) forwards;
+  animation: tx-route-out-fwd 220ms var(--tx-ease) forwards;
 }
 ::view-transition-new(root) {
-  animation: tx-route-in 220ms var(--tx-ease) forwards;
+  animation: tx-route-in-fwd 220ms var(--tx-ease) forwards;
 }
-@keyframes tx-route-out {
+[data-nav-direction='back']::view-transition-old(root) {
+  animation: tx-route-out-back 220ms var(--tx-ease) forwards;
+}
+[data-nav-direction='back']::view-transition-new(root) {
+  animation: tx-route-in-back 220ms var(--tx-ease) forwards;
+}
+@keyframes tx-route-out-fwd {
   to { opacity: 0; transform: translateX(-6%); }
 }
-@keyframes tx-route-in {
+@keyframes tx-route-in-fwd {
   from { opacity: 0; transform: translateX(6%); }
+  to { opacity: 1; transform: translateX(0); }
+}
+@keyframes tx-route-out-back {
+  to { opacity: 0; transform: translateX(6%); }
+}
+@keyframes tx-route-in-back {
+  from { opacity: 0; transform: translateX(-6%); }
   to { opacity: 1; transform: translateX(0); }
 }
 [data-motion='minimal'] ::view-transition-old(root),


### PR DESCRIPTION
Prima ogni cambio di schermata aveva la stessa animazione: la pagina vecchia usciva sempre verso sinistra e quella nuova entrava sempre da destra, anche quando l'utente premeva Indietro. Ora la direzione segue il gesto: andando avanti la pagina entra da destra, tornando indietro (tasto del browser, X di partita, freccia back nell'app-bar) la pagina entra da sinistra. E' un dettaglio piccolo ma rende molto piu' "fisica" la navigazione: capisci a colpo d'occhio dove sei in gerarchia.

Sui browser senza View Transitions API il cambio resta istantaneo, niente di rotto. Con animazioni Minime nelle impostazioni le transizioni restano disattivate come prima.