### PR TITLE
feat(badges): allinea teaser, pagina e modale al mockup

### DIFF
--- a/src/app/features/badges/badges.css
+++ b/src/app/features/badges/badges.css
@@ -10,6 +10,7 @@
 .badges-summary {
   display: flex;
   align-items: baseline;
+  justify-content: flex-start;
   gap: 10px;
   margin-top: 4px;
 }

--- a/src/app/features/badges/badges.css
+++ b/src/app/features/badges/badges.css
@@ -1,42 +1,35 @@
 .badges-page {
   display: flex;
   flex-direction: column;
-  gap: 18px;
   padding-bottom: 32px;
 }
 
+/* Riepilogo: numero molto grande "X/Y" (Y in text-mute), label "sbloccati"
+   accanto alla baseline, e barra sottile a tutta larghezza sotto. Niente card,
+   come nel mockup. */
 .badges-summary {
   display: flex;
-  align-items: center;
-  gap: 16px;
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  padding: 16px 18px;
-}
-
-.badges-count {
-  display: flex;
   align-items: baseline;
-  gap: 6px;
+  gap: 10px;
+  margin-top: 4px;
+}
+.badges-count {
+  display: inline-flex;
+  align-items: baseline;
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 36px;
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
 }
 .badges-count .v {
-  font-family: var(--font-display);
-  font-weight: 700;
-  font-size: 32px;
-  color: var(--accent);
-  line-height: 1;
+  color: var(--text);
 }
 .badges-count .l {
-  font-size: 14px;
-  color: var(--text-dim);
+  color: var(--text-mute);
 }
-
-.badges-progress {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
+.badges-count-label {
+  font-size: 13px;
 }
 
 .badges-bar {
@@ -45,6 +38,7 @@
   background: var(--border);
   border-radius: 999px;
   overflow: hidden;
+  margin-top: 14px;
 }
 .badges-bar i {
   display: block;
@@ -53,14 +47,14 @@
   transition: width 240ms var(--tx-ease);
 }
 
-.badges-progress-label {
-  font-size: 12px;
+.badges-section-title {
+  margin: 22px 0 10px;
 }
 
 .badges-grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: 8px;
+  gap: 10px;
 }
 
 /* Le classi .badge-card, .badge-icon, .badge-title e .badge-prog vivono in styles.css
@@ -73,22 +67,18 @@
   z-index: 80;
 }
 .badge-sheet {
-  max-width: 380px;
-  border-radius: 20px;
-  padding: 22px;
-  animation: pop .18s ease;
+  max-width: 400px;
+  border-radius: 24px;
+  padding: 24px 24px 28px;
+  animation: pop .2s ease;
   text-align: center;
   position: relative;
 }
-.badge-close {
-  position: absolute;
-  top: 12px;
-  right: 12px;
-}
 
 /* Sheet dettaglio traguardo: hero stacked (icona sopra, status sotto, tutto
-   centrato), titolo e descrizione centrati, card "come sbloccarlo" allineata
-   a sinistra, barra di progresso con etichetta sotto. */
+   centrato), titolo e descrizione centrati. La card "come sbloccarlo" e'
+   visibile solo per i traguardi locked. In fondo c'e' sempre il bottone primary
+   "Chiudi" (al posto della X in alto del vecchio design). */
 .badge-sheet-hero {
   display: flex;
   flex-direction: column;
@@ -125,11 +115,16 @@
   border: 1px solid var(--border);
   border-radius: 12px;
   padding: 14px 16px;
-  margin-bottom: 22px;
+  margin-bottom: 18px;
+}
+/* L'eyebrow "COME SBLOCCARLO" e' warm (ambra), per dare urgenza visiva
+   all'azione da compiere. Solo qui dentro, altri eyebrow restano text-mute. */
+.badge-sheet-quest .quest-eyebrow {
+  color: var(--warm);
 }
 .badge-sheet-quest p {
-  margin: 8px 0 0;
-  font-size: 13px;
+  margin: 8px 0 12px;
+  font-size: 14px;
   line-height: 1.5;
   color: var(--text);
 }
@@ -153,8 +148,12 @@
   transition: width 240ms var(--tx-ease);
 }
 .badge-bar-label {
-  display: flex;
-  justify-content: center;
-  gap: 4px;
+  text-align: right;
+  font-family: var(--font-mono);
   font-size: 12px;
+  font-variant-numeric: tabular-nums;
+}
+
+.badge-sheet-close {
+  margin-top: 4px;
 }

--- a/src/app/features/badges/badges.html
+++ b/src/app/features/badges/badges.html
@@ -4,16 +4,17 @@
   <div class="page badges-page">
     <div class="badges-summary">
       <div class="badges-count">
-        <span class="v">{{ unlocked() }}</span>
-        <span class="l">/ {{ total() }}</span>
+        <span class="v">{{ unlocked() }}</span><span class="l">/{{ total() }}</span>
       </div>
-      <div class="badges-progress">
-        <div class="badges-bar"><i [style.width.%]="progress() * 100"></i></div>
-        <span class="muted badges-progress-label">
-          {{ i18n.lang() === 'it' ? 'Traguardi sbloccati' : 'Badges unlocked' }}
-        </span>
-      </div>
+      <span class="muted badges-count-label">
+        {{ i18n.lang() === 'it' ? 'sbloccati' : 'unlocked' }}
+      </span>
     </div>
+    <div class="badges-bar"><i [style.width.%]="progress() * 100"></i></div>
+
+    <h3 class="h3 badges-section-title">
+      {{ i18n.lang() === 'it' ? 'Tutti i traguardi' : 'All achievements' }}
+    </h3>
 
     <div class="badges-grid">
       @for (b of badges(); track b.id) {
@@ -37,10 +38,6 @@
   @if (detail(); as d) {
     <div class="sheet-backdrop badge-backdrop" (click)="closeDetail()">
       <div class="sheet badge-sheet" (click)="$event.stopPropagation()">
-        <button class="btn-icon badge-close" type="button" (click)="closeDetail()" aria-label="Close">
-          <app-icon name="close" />
-        </button>
-
         <div class="badge-sheet-hero">
           <div class="badge-icon-lg" [attr.data-unlocked]="d.unlocked ? '1' : '0'" [attr.data-tier]="d.tier">
             {{ d.icon }}
@@ -55,18 +52,24 @@
         <h2 class="h2 badge-sheet-title">{{ titleOf(d) }}</h2>
         <p class="muted badge-sheet-desc">{{ descOf(d) }}</p>
 
-        <div class="badge-sheet-quest">
-          <span class="eyebrow">{{ i18n.lang() === 'it' ? 'COME SBLOCCARLO' : 'HOW TO UNLOCK' }}</span>
-          <p>{{ questOf(d) }}</p>
-        </div>
-
-        <div class="badge-sheet-progress">
-          <div class="badge-bar"><i [style.width.%]="progressPct(d)"></i></div>
-          <div class="badge-bar-label muted">
-            <span>{{ d.valueOf(state()) }}</span>
-            <span>/ {{ d.target }}</span>
+        @if (!d.unlocked) {
+          <div class="badge-sheet-quest">
+            <span class="eyebrow quest-eyebrow">
+              {{ i18n.lang() === 'it' ? 'COME SBLOCCARLO' : 'HOW TO UNLOCK' }}
+            </span>
+            <p>{{ questOf(d) }}</p>
+            <div class="badge-sheet-progress">
+              <div class="badge-bar"><i [style.width.%]="progressPct(d)"></i></div>
+              <div class="badge-bar-label muted">
+                <span>{{ d.valueOf(state()) }} / {{ d.target }}</span>
+              </div>
+            </div>
           </div>
-        </div>
+        }
+
+        <button class="btn btn-primary btn-block badge-sheet-close" type="button" (click)="closeDetail()">
+          {{ i18n.lang() === 'it' ? 'Chiudi' : 'Close' }}
+        </button>
       </div>
     </div>
   }

--- a/src/app/features/badges/badges.ts
+++ b/src/app/features/badges/badges.ts
@@ -5,11 +5,10 @@ import { I18nService } from '../../core/i18n/i18n.service';
 import { AppStateService } from '../../core/state/app-state.service';
 import { BadgeWithProgress, computeBadges } from '../../core/data/badges';
 import { AppBar } from '../../shared/app-bar';
-import { Icon } from '../../shared/icon';
 
 @Component({
   selector: 'app-badges',
-  imports: [AppBar, Icon],
+  imports: [AppBar],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './badges.html',
   styleUrl: './badges.css',

--- a/src/app/features/home/home.css
+++ b/src/app/features/home/home.css
@@ -106,6 +106,11 @@
 }
 .badges-teaser-text {
   min-width: 0;
+  /* La .badges-teaser e' un <button> che di default impone text-align: center
+     al contenuto inline. Forziamo left perche' titolo + sottotitolo qui sono
+     blocchi di testo block-level e devono restare allineati a sinistra come nel
+     mockup. */
+  text-align: left;
 }
 .badges-teaser-title {
   font-weight: 500;

--- a/src/app/features/home/home.css
+++ b/src/app/features/home/home.css
@@ -95,35 +95,38 @@
 .stats-grid > .stat:hover { background: var(--surface-2); }
 .stats-grid > .stat:active { transform: translateY(1px); }
 
-/* Il container .badges-teaser e i cerchi `.icons > span[data-on][data-t]` sono
-   stylati in styles.css globale, identici al prototipo. Qui forziamo la
-   larghezza al 100% (il button HTML e' inline di default), riduciamo
-   leggermente il padding verticale e mettiamo numero / totale / label tutto
-   su una riga sola, centrata verticalmente. */
+/* La card .badges-teaser e' definita in styles.css globale (grid 1fr auto,
+   border, hover). Qui sovrascriviamo solo il contenuto della colonna di
+   sinistra: titolo "Traguardi · 3 / 10" con il numero in accent + sottotitolo
+   informativo che cambia in base allo stato ("Comincia a giocare..." oppure
+   "X sbloccati. Prossimo: Y"). Match al mockup, non al layout meta+icons
+   compatto di prima. */
 .badges-teaser {
   width: 100%;
-  padding-top: 10px;
-  padding-bottom: 10px;
 }
-.badges-teaser-meta {
-  display: flex;
-  align-items: baseline;
-  gap: 4px;
-  line-height: 1;
+.badges-teaser-text {
+  min-width: 0;
 }
-.badges-teaser-meta .v {
-  font-family: var(--font-display);
-  font-weight: 700;
-  font-size: 17px;
+.badges-teaser-title {
+  font-weight: 500;
+  font-size: 15px;
+  line-height: 1.2;
+}
+.badges-teaser-title .sep {
+  color: var(--text-mute);
+  margin: 0 2px;
+}
+.badges-teaser-title .v {
   color: var(--accent);
+  font-weight: 600;
 }
-.badges-teaser-meta .l {
-  font-size: 13px;
-  color: var(--text-dim);
+.badges-teaser-title .l {
+  color: var(--text-mute);
 }
-.badges-teaser-label {
+.badges-teaser-sub {
   font-size: 12px;
-  margin-left: 6px;
+  margin-top: 4px;
+  line-height: 1.4;
 }
 
 /* Le icone di modalita' (emoji ∞ / ⏱ / ♥) restano centrate nel quadratino

--- a/src/app/features/home/home.html
+++ b/src/app/features/home/home.html
@@ -156,10 +156,26 @@
       </button>
     </div>
     <button class="badges-teaser" type="button" (click)="goBadges()">
-      <div class="badges-teaser-meta">
-        <span class="v">{{ badgeStats().unlocked }}</span>
-        <span class="l">/ {{ badgeStats().total }}</span>
-        <span class="muted badges-teaser-label">{{ i18n.lang() === 'it' ? 'sbloccati' : 'unlocked' }}</span>
+      <div class="badges-teaser-text">
+        <div class="badges-teaser-title">
+          {{ i18n.t('badges') }}
+          <span class="sep" aria-hidden="true">·</span>
+          <span class="v">{{ badgeStats().unlocked }}</span>
+          <span class="l">/ {{ badgeStats().total }}</span>
+        </div>
+        <div class="badges-teaser-sub muted">
+          @if (badgeStats().unlocked === 0) {
+            {{ i18n.lang() === 'it'
+              ? 'Comincia a giocare per sbloccare il primo.'
+              : 'Start playing to unlock your first one.' }}
+          } @else if (!badgeStats().nextLocked) {
+            {{ i18n.lang() === 'it' ? 'Li hai sbloccati tutti.' : 'You unlocked them all.' }}
+          } @else if (i18n.lang() === 'it') {
+            {{ badgeStats().unlocked }} sbloccati. Prossimo: {{ nextLockedTitle() }}
+          } @else {
+            {{ badgeStats().unlocked }} unlocked. Next: {{ nextLockedTitle() }}
+          }
+        </div>
       </div>
       <div class="icons">
         @for (b of badgeStats().preview; track b.id) {

--- a/src/app/features/home/home.ts
+++ b/src/app/features/home/home.ts
@@ -115,9 +115,23 @@ export class Home {
 
   protected readonly badgeStats = computed(() => {
     const list = computeBadges(this.state());
-    const unlocked = list.filter((b) => b.unlocked).length;
-    return { total: list.length, unlocked, preview: list.slice(0, 4) };
+    const unlocked = list.filter((b) => b.unlocked);
+    const locked = list
+      .filter((b) => !b.unlocked)
+      .sort((a, b) => b.progress - a.progress);
+    const preview = [
+      ...unlocked.slice(0, 2),
+      ...locked.slice(0, 4 - Math.min(unlocked.length, 2)),
+    ].slice(0, 4);
+    const nextLocked = locked[0] ?? null;
+    return { total: list.length, unlocked: unlocked.length, preview, nextLocked };
   });
+
+  protected nextLockedTitle(): string {
+    const next = this.badgeStats().nextLocked;
+    if (!next) return '';
+    return this.i18n.lang() === 'en' ? next.titleEn : next.titleIt;
+  }
 
   protected goSelection(mode: 'training' | 'timed' | 'survival'): void {
     this.router.navigate(['/selection'], { queryParams: { mode } });


### PR DESCRIPTION
Tre ritocchi alla sezione traguardi per avvicinarla al prototipo di Claude Design.

Nella home la card dei traguardi adesso e' piu' parlante: invece di un secco "3/10 sbloccati" leggi "Traguardi · 3/10" con il numero in accent, e sotto una riga discorsiva che racconta cosa fare dopo: "3 sbloccati. Prossimo: Maratona". Se non hai ancora nessun traguardo ti suggerisce di iniziare a giocare; se li hai presi tutti te lo dice. Le quattro icone in anteprima ora vengono scelte con la logica del mockup, prima quelle sbloccate (max due) poi le piu' vicine al traguardo, cosi' vedi sempre qualcosa di significativo.

Nella pagina /traguardi e' sparita la card riassuntiva orizzontale e al suo posto c'e' un grande "X/Y sbloccati" molto leggibile, una barra di progresso sottile a tutta larghezza, e il titolo di sezione "Tutti i traguardi" sopra la griglia. Sensazione meno "moduletto", piu' pagina vera.

Nella modale di dettaglio del singolo traguardo, la X piccola in alto a destra non c'e' piu': si chiude con un grosso bottone "Chiudi" in fondo, piu' raggiungibile col pollice da mobile. Su un traguardo gia' sbloccato la modale non mostra piu' la scheda "come sbloccarlo" e la barra di progresso al 100%, che erano informazione ridondante. Sui locked invece l'etichetta "COME SBLOCCARLO" e' diventata ambra per spingere l'occhio sul prossimo obiettivo.