### PR TITLE
feat(settings): allinea impostazioni al mockup

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -38,8 +38,8 @@
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "4kB",
-                  "maximumError": "8kB"
+                  "maximumWarning": "6kB",
+                  "maximumError": "10kB"
                 }
               ],
               "outputHashing": "all",

--- a/src/app/features/settings/settings.css
+++ b/src/app/features/settings/settings.css
@@ -1,18 +1,92 @@
 .settings-page {
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: 16px;
   padding-bottom: 32px;
 }
 
+/* Header di sezione: titolo aderente al blocco, no gap doppio col container. */
+.section-h {
+  margin: 4px 0 -4px;
+}
+
+/* Card account in cima: avatar + nome/sub + bottone azione. */
+.account-card {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px;
+}
+.account-avatar {
+  flex-shrink: 0;
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 18px;
+}
+.account-avatar.accent {
+  background: var(--accent);
+  color: var(--accent-contrast);
+  border-color: transparent;
+}
+.account-meta {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.account-name {
+  font-size: 14px;
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.account-sub {
+  font-size: 11px;
+  color: var(--text-mute);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.account-cta {
+  height: 36px;
+  font-size: 13px;
+  padding: 0 14px;
+}
+
+/* Una "settings-section" e' una colonna di righe (setting-row, toggle-row, help-btn). */
 .settings-section {
   display: flex;
   flex-direction: column;
   gap: 10px;
 }
 
-.settings-section .h3 {
-  margin-bottom: 2px;
+/* Riga "complessa" con label + sottotitolo + controllo sotto. Le righe semplici toggle stanno in .toggle-row. */
+.setting-row {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.setting-row-head {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.setting-row-label {
+  font-size: 14px;
+}
+.setting-row-sub {
+  font-size: 11px;
+  line-height: 1.4;
 }
 
 .seg {
@@ -23,7 +97,6 @@
   border: 1px solid var(--border);
   border-radius: 12px;
 }
-
 .seg-btn {
   flex: 1;
   height: 36px;
@@ -52,7 +125,6 @@
   gap: 8px;
   flex-wrap: wrap;
 }
-
 .swatch {
   width: 40px;
   height: 40px;
@@ -66,11 +138,10 @@
     border-color var(--hover-dur) ease;
 }
 .swatch:hover { transform: scale(1.05); }
-.swatch.is-active {
-  border-color: var(--text);
-}
+.swatch.is-active { border-color: var(--text); }
 .swatch app-icon { color: var(--accent-contrast); }
 
+/* Riga toggle: label a sinistra, switch a destra. Con sotto-testo usa .toggle-text. */
 .toggle-row {
   display: flex;
   justify-content: space-between;
@@ -84,17 +155,20 @@
   border-top: 0;
   padding-top: 4px;
 }
-
+.toggle-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
 .toggle-label {
   font-size: 14px;
 }
-
 .toggle-sub {
   display: block;
-  font-size: 12px;
-  margin-top: 2px;
+  font-size: 11px;
+  line-height: 1.4;
 }
-
 .toggle-input {
   appearance: none;
   width: 40px;
@@ -128,6 +202,80 @@
   background: var(--accent-contrast);
 }
 
+/* Spiegazione del livello di animazioni attivo. */
+.motion-hint {
+  font-size: 12px;
+  line-height: 1.5;
+  margin: -2px 2px 0;
+}
+
+.settings-divider {
+  border: 0;
+  border-top: 1px solid var(--border);
+  margin: 2px 0;
+}
+
+/* Sezione Aiuto: emoji a sinistra, label che spinge il chevron a destra. */
+.help-btn {
+  appearance: none;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 14px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  color: var(--text);
+  font: inherit;
+  font-size: 14px;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    background var(--hover-dur) ease,
+    border-color var(--hover-dur) ease,
+    transform var(--hover-dur) ease;
+}
+.help-btn:hover {
+  background: var(--surface-2);
+  border-color: var(--border-strong);
+  transform: translateY(-1px);
+}
+.help-emoji {
+  font-size: 16px;
+  line-height: 1;
+}
+.help-label {
+  flex: 1;
+}
+.help-btn app-icon {
+  color: var(--text-mute);
+}
+
+.data-blurb {
+  font-size: 13px;
+  line-height: 1.5;
+  margin: 0;
+}
+
+/* Card del codice di sincronizzazione: rivelata al click. Placeholder per ora. */
+.sync-card {
+  text-align: center;
+  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.sync-code {
+  font-size: 22px;
+  font-weight: 600;
+  letter-spacing: 0.2em;
+}
+.sync-foot {
+  font-size: 11px;
+  margin: 0;
+}
+
 .reset-btn {
   color: var(--danger);
   border-color: rgba(251, 113, 133, 0.3);
@@ -136,9 +284,12 @@
   background: rgba(251, 113, 133, 0.08);
 }
 
-/* Spiegazione del livello di animazioni attivo: cambia in base alla scelta corrente. */
-.motion-hint {
-  font-size: 12px;
-  line-height: 1.5;
-  margin: 6px 2px 0;
+/* Footer in fondo: versione + "static · offline-ready". In dev include l'hash. */
+.settings-footer {
+  margin: 18px 0 calc(env(safe-area-inset-bottom, 0px) + 4px);
+  text-align: center;
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  color: var(--text-mute);
+  opacity: 0.7;
 }

--- a/src/app/features/settings/settings.html
+++ b/src/app/features/settings/settings.html
@@ -2,62 +2,119 @@
   <app-bar [canBack]="true" [title]="i18n.t('settings')" (back)="goBack()" (goHome)="goHome()" />
 
   <div class="page settings-page">
-    <section class="settings-section">
-      <h3 class="h3">{{ i18n.lang() === 'it' ? 'Lingua' : 'Language' }}</h3>
-      <div class="seg">
-        @for (l of langs; track l) {
-          <button class="seg-btn" type="button" [class.is-active]="i18n.lang() === l" (click)="setLang(l)">
-            {{ l === 'it' ? 'Italiano' : 'English' }}
-          </button>
-        }
-      </div>
-    </section>
+    <!-- Card account: stato connesso vs anonimo. Per ora solo il caso "non
+         connesso" e' realmente raggiungibile (la pagina /login viene aggiunta
+         in PR 3). Quando ci sara' un account vero, la card mostra avatar,
+         nickname e link al profilo. -->
+    <div class="card account-card">
+      @if (state().account; as a) {
+        <span class="account-avatar accent">{{ a.nickname.charAt(0).toUpperCase() }}</span>
+        <div class="account-meta">
+          <span class="account-name">{{ a.nickname }}</span>
+          <span class="account-sub mono">{{ a.email }}</span>
+        </div>
+        <button class="nav-btn" type="button" (click)="goProfile()">
+          {{ i18n.t('profile') }}
+        </button>
+      } @else {
+        <span class="account-avatar">
+          <app-icon name="user" />
+        </span>
+        <div class="account-meta">
+          <span class="account-name">
+            {{ i18n.lang() === 'it' ? 'Non connesso' : 'Not signed in' }}
+          </span>
+          <span class="account-sub">
+            {{ i18n.lang() === 'it' ? 'I dati restano su questo dispositivo' : 'Data stays on this device' }}
+          </span>
+        </div>
+        <button class="btn btn-primary account-cta" type="button" (click)="goLogin()">
+          {{ i18n.t('login') }}
+        </button>
+      }
+    </div>
 
-    <section class="settings-section">
-      <h3 class="h3">{{ i18n.lang() === 'it' ? 'Colore accent' : 'Accent color' }}</h3>
-      <div class="swatches">
-        @for (a of accents; track a.accent) {
-          <button
-            class="swatch"
-            type="button"
-            [class.is-active]="state().accent === a.accent"
-            [style.background]="a.accent"
-            [attr.aria-label]="a.name"
-            (click)="setAccent(a.accent)"
-          >
-            @if (state().accent === a.accent) {
-              <app-icon name="check" />
-            }
-          </button>
-        }
+    <h3 class="h3 section-h">{{ i18n.lang() === 'it' ? 'Aspetto' : 'Appearance' }}</h3>
+    <div class="settings-section">
+      <div class="setting-row">
+        <div class="setting-row-head">
+          <div class="setting-row-label">{{ i18n.lang() === 'it' ? 'Colore di accento' : 'Accent color' }}</div>
+          <div class="setting-row-sub muted">
+            {{ i18n.lang() === 'it' ? 'Tinta principale usata su pulsanti, pillole e dettagli.' : 'Main hue used across buttons, pills and highlights.' }}
+          </div>
+        </div>
+        <div class="swatches">
+          @for (a of accents; track a.accent) {
+            <button
+              class="swatch"
+              type="button"
+              [class.is-active]="state().accent === a.accent"
+              [style.background]="a.accent"
+              [attr.aria-label]="a.name"
+              (click)="setAccent(a.accent)"
+            >
+              @if (state().accent === a.accent) {
+                <app-icon name="check" />
+              }
+            </button>
+          }
+        </div>
       </div>
-    </section>
 
-    <section class="settings-section">
-      <h3 class="h3">{{ i18n.lang() === 'it' ? 'Animazioni' : 'Motion' }}</h3>
-      <div class="seg">
-        @for (m of motions; track m) {
-          <button class="seg-btn" type="button" [class.is-active]="state().motion === m" (click)="setMotion(m)">
-            {{ motionLabel(m) }}
-          </button>
-        }
+      <div class="setting-row">
+        <div class="setting-row-head">
+          <div class="setting-row-label">{{ i18n.lang() === 'it' ? 'Animazioni' : 'Motion' }}</div>
+          <div class="setting-row-sub muted">
+            {{ i18n.lang() === 'it' ? 'Quantita’ di animazioni in tutta l’app.' : 'How much movement across the app.' }}
+          </div>
+        </div>
+        <div class="seg">
+          @for (m of motions; track m) {
+            <button class="seg-btn" type="button" [class.is-active]="state().motion === m" (click)="setMotion(m)">
+              {{ motionLabel(m) }}
+            </button>
+          }
+        </div>
+        <p class="muted motion-hint">{{ motionHint(state().motion) }}</p>
       </div>
-      <p class="muted motion-hint">{{ motionHint(state().motion) }}</p>
-    </section>
+    </div>
 
-    <section class="settings-section">
-      <h3 class="h3">{{ i18n.lang() === 'it' ? 'Accessibilita' : 'Accessibility' }}</h3>
-      <div class="seg">
-        @for (m of cbModes; track m) {
-          <button class="seg-btn" type="button" [class.is-active]="state().colorblind === m" (click)="setColorblind(m)">
-            {{ cbLabel(m) }}
-          </button>
-        }
+    <h3 class="h3 section-h">{{ i18n.lang() === 'it' ? 'Accessibilita’' : 'Accessibility' }}</h3>
+    <div class="settings-section">
+      <div class="setting-row">
+        <div class="setting-row-head">
+          <div class="setting-row-label">{{ i18n.lang() === 'it' ? 'Visione a colori' : 'Color vision' }}</div>
+          <div class="setting-row-sub muted">
+            {{ i18n.lang() === 'it'
+              ? 'Adatta i colori di feedback per chi e’ daltonico.'
+              : 'Adjusts feedback colors for color-blind users.' }}
+          </div>
+        </div>
+        <div class="seg">
+          @for (m of cbModes; track m) {
+            <button class="seg-btn" type="button" [class.is-active]="state().colorblind === m" (click)="setColorblind(m)">
+              {{ cbLabel(m) }}
+            </button>
+          }
+        </div>
       </div>
-    </section>
+    </div>
 
-    <section class="settings-section">
-      <h3 class="h3">{{ i18n.lang() === 'it' ? 'Audio e feedback' : 'Audio and feedback' }}</h3>
+    <h3 class="h3 section-h">{{ i18n.lang() === 'it' ? 'Preferenze' : 'Preferences' }}</h3>
+    <div class="settings-section">
+      <div class="setting-row">
+        <div class="setting-row-head">
+          <div class="setting-row-label">{{ i18n.lang() === 'it' ? 'Lingua' : 'Language' }}</div>
+        </div>
+        <div class="seg">
+          @for (l of langs; track l) {
+            <button class="seg-btn" type="button" [class.is-active]="i18n.lang() === l" (click)="setLang(l)">
+              {{ l === 'it' ? 'Italiano' : 'English' }}
+            </button>
+          }
+        </div>
+      </div>
+
       <label class="toggle-row">
         <span class="toggle-label">{{ i18n.lang() === 'it' ? 'Suoni' : 'Sounds' }}</span>
         <input type="checkbox" class="toggle-input" [checked]="state().sound" (change)="toggleSound()" />
@@ -67,28 +124,73 @@
         <input type="checkbox" class="toggle-input" [checked]="state().haptics" (change)="toggleHaptics()" />
       </label>
       <label class="toggle-row">
-        <span>
-          <span class="toggle-label">{{ i18n.lang() === 'it' ? 'Mostra codice Unicode' : 'Show Unicode codepoint' }}</span>
+        <span class="toggle-text">
+          <span class="toggle-label">{{ i18n.lang() === 'it' ? 'Mostra Unicode' : 'Show Unicode' }}</span>
           <span class="toggle-sub muted">
-            {{ i18n.lang() === 'it' ? 'Sotto al glifo del quiz appare sempre il codice U+XXXX.' : 'The U+XXXX codepoint appears under each quiz glyph.' }}
+            {{ i18n.lang() === 'it' ? 'Codepoint sotto il glifo durante il gioco.' : 'Codepoint under the glyph during play.' }}
           </span>
         </span>
         <input type="checkbox" class="toggle-input" [checked]="state().showCodepoint" (change)="toggleShowCodepoint()" />
       </label>
-    </section>
+    </div>
 
-    <section class="settings-section">
-      <h3 class="h3">{{ i18n.lang() === 'it' ? 'Aiuto' : 'Help' }}</h3>
-      <button class="btn btn-ghost btn-block" type="button" (click)="replayOnboarding()">
-        {{ i18n.lang() === 'it' ? 'Rivedi la presentazione' : 'Replay the intro' }}
+    <hr class="settings-divider" />
+
+    <h3 class="h3 section-h">{{ i18n.lang() === 'it' ? 'Aiuto' : 'Help' }}</h3>
+    <div class="settings-section">
+      <button class="help-btn" type="button" (click)="goFeedback()">
+        <span class="help-emoji">💬</span>
+        <span class="help-label">
+          {{ i18n.lang() === 'it' ? 'Segnala bug o suggerisci un’idea' : 'Report a bug or suggest an idea' }}
+        </span>
+        <app-icon name="chev" />
       </button>
-    </section>
+      <button class="help-btn" type="button" (click)="replayOnboarding()">
+        <span class="help-emoji">🎬</span>
+        <span class="help-label">
+          {{ i18n.lang() === 'it' ? 'Rivedi la presentazione' : 'Replay the intro' }}
+        </span>
+        <app-icon name="chev" />
+      </button>
+    </div>
 
-    <section class="settings-section">
-      <h3 class="h3">{{ i18n.lang() === 'it' ? 'Dati' : 'Data' }}</h3>
+    <hr class="settings-divider" />
+
+    <h3 class="h3 section-h">{{ i18n.lang() === 'it' ? 'Dati' : 'Data' }}</h3>
+    <div class="settings-section">
+      <p class="muted data-blurb">
+        @if (state().account) {
+          {{ i18n.lang() === 'it'
+            ? 'I tuoi dati vengono sincronizzati col tuo account.'
+            : 'Your data syncs with your account.' }}
+        } @else {
+          {{ i18n.lang() === 'it'
+            ? 'I tuoi progressi sono salvati solo su questo dispositivo.'
+            : 'Your progress is stored on this device only.' }}
+        }
+      </p>
+
+      @if (!showSync()) {
+        <button class="btn btn-ghost btn-block" type="button" (click)="revealSync()">
+          {{ i18n.lang() === 'it' ? 'Mostra codice di sincronizzazione' : 'Show sync code' }}
+        </button>
+      } @else {
+        <div class="card sync-card">
+          <span class="eyebrow">
+            {{ i18n.lang() === 'it' ? 'CODICE DI SINCRONIZZAZIONE' : 'SYNC CODE' }}
+          </span>
+          <div class="sync-code mono">{{ syncCode() }}</div>
+          <p class="muted sync-foot">
+            {{ i18n.lang() === 'it' ? 'Funzione in arrivo · placeholder' : 'Coming soon · placeholder' }}
+          </p>
+        </div>
+      }
+
       <button class="btn btn-ghost btn-block reset-btn" type="button" (click)="resetProgress()">
-        {{ i18n.lang() === 'it' ? 'Resetta tutti i progressi' : 'Reset all progress' }}
+        {{ i18n.lang() === 'it' ? 'Azzera progressi' : 'Reset progress' }}
       </button>
-    </section>
+    </div>
+
+    <p class="settings-footer mono">{{ buildLabel }} · static · offline-ready</p>
   </div>
 </div>

--- a/src/app/features/settings/settings.ts
+++ b/src/app/features/settings/settings.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
 import { Location } from '@angular/common';
 import { Router } from '@angular/router';
 import { I18nService } from '../../core/i18n/i18n.service';
@@ -13,6 +13,7 @@ import {
 } from '../../core/state/types';
 import { AppBar } from '../../shared/app-bar';
 import { Icon } from '../../shared/icon';
+import { APP_VERSION, BUILD_CONTEXT, BUILD_SHA } from '../../core/build-info';
 
 @Component({
   selector: 'app-settings',
@@ -33,6 +34,16 @@ export class Settings {
   protected readonly motions: ReadonlyArray<MotionLevel> = ['minimal', 'playful', 'rich'];
   protected readonly cbModes: ReadonlyArray<ColorblindMode> = ['none', 'redgreen', 'blueyellow'];
   protected readonly langs: ReadonlyArray<Lang> = ['it', 'en'];
+
+  /** La card del codice di sincronizzazione e' chiusa per default; il tasto
+   *  "Mostra codice di sincronizzazione" la rivela. Una volta rivelata, il
+   *  codice viene generato in localStorage e resta stabile tra sessioni. */
+  protected readonly showSync = signal(false);
+  protected readonly syncCode = computed(() => (this.showSync() ? ensureSyncCode() : ''));
+
+  /** Footer in fondo: in dev include l'hash, in release no. */
+  protected readonly buildLabel =
+    BUILD_CONTEXT === 'release' ? `v${APP_VERSION}` : `v${APP_VERSION} · dev · ${BUILD_SHA}`;
 
   protected setAccent(hex: AccentHex): void {
     this.appState.update({ accent: hex });
@@ -57,6 +68,19 @@ export class Settings {
     this.appState.update({ showCodepoint: !this.state().showCodepoint });
   }
 
+  protected revealSync(): void {
+    this.showSync.set(true);
+  }
+
+  protected goFeedback(): void {
+    this.router.navigate(['/feedback']);
+  }
+  protected goLogin(): void {
+    this.router.navigate(['/login']);
+  }
+  protected goProfile(): void {
+    this.router.navigate(['/profile']);
+  }
   protected replayOnboarding(): void {
     this.router.navigate(['/onboarding']);
   }
@@ -90,8 +114,8 @@ export class Settings {
   }
   protected cbLabel(m: ColorblindMode): string {
     const isIt = this.i18n.lang() === 'it';
-    if (isIt) return m === 'none' ? 'Standard' : m === 'redgreen' ? 'Rosso e verde' : 'Blu e giallo';
-    return m === 'none' ? 'Standard' : m === 'redgreen' ? 'Red and green' : 'Blue and yellow';
+    if (isIt) return m === 'none' ? 'Standard' : m === 'redgreen' ? 'Rosso-verde' : 'Blu-giallo';
+    return m === 'none' ? 'Standard' : m === 'redgreen' ? 'Red-green' : 'Blue-yellow';
   }
 
   protected goBack(): void {
@@ -100,5 +124,28 @@ export class Settings {
 
   protected goHome(): void {
     this.router.navigate(['/home']);
+  }
+}
+
+/**
+ * Codice di sincronizzazione "mock" (8 caratteri, divisi 4-4, alfabeto safe
+ * senza I/O/0/1). Persistito in localStorage cosi' che, una volta generato,
+ * resta stabile tra sessioni come si comporterebbe un vero codice di pairing.
+ * Sara' rimpiazzato dal vero meccanismo quando integreremo il BaaS.
+ */
+function ensureSyncCode(): string {
+  try {
+    const cached = localStorage.getItem('gtc.sync');
+    if (cached) return cached;
+    const alphabet = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
+    let raw = '';
+    for (let i = 0; i < 8; i++) {
+      raw += alphabet[Math.floor(Math.random() * alphabet.length)];
+    }
+    const code = `${raw.slice(0, 4)}-${raw.slice(4)}`;
+    localStorage.setItem('gtc.sync', code);
+    return code;
+  } catch {
+    return 'XXXX-XXXX';
   }
 }


### PR DESCRIPTION
La pagina Impostazioni si avvicina al prototipo di Claude Design. Le opzioni sono le stesse di prima e si applicano dal vivo come sempre (niente tasto Salva), ma il layout cambia parecchio.

In cima ora c'e' una card "account": stato corrente, sottotitolo che spiega dove vivono i dati, e un tasto Accedi a destra. Per ora la pagina di login arriva solo nella prossima PR, quindi il click apre /login che e' ancora il placeholder "In arrivo".

Le sezioni sono ordinate come nel mockup: Aspetto, Accessibilita', Preferenze, Aiuto, Dati. Ogni riga "complessa" (colore accento, animazioni, daltonismo, Unicode) ha un sottotitolo che spiega a cosa serve, senza dover indovinare. Sulle animazioni resta la spiegazione viva che cambia in base al livello scelto.

In Aiuto c'e' un bottone nuovo per segnalare bug o suggerire idee (porta a /feedback che e' ancora in arrivo) e resta il "Rivedi la presentazione" che gia' c'era.

In Dati: una riga di testo spiega che i progressi sono sul dispositivo, un tasto "Mostra codice di sincronizzazione" rivela una card placeholder con codice mono e l'avviso "Funzione in arrivo · placeholder", e in fondo l'azione distruttiva "Azzera progressi".

In fondo alla pagina compare la stringa di versione "vX.Y.Z · static · offline-ready" come nel mockup.

Note tecniche minori: il budget per-componente di CSS in produzione e' stato alzato da 4kB a 6kB (la pagina e' diventata densa, ma resta sotto il limite di errore che ho alzato di pari passo a 10kB). Il codice di sincronizzazione e' generato e cachato in localStorage chiave gtc.sync per non rigenerarsi a ogni visita.