### PR TITLE
feat(auth): pagina di login + logout + menu account

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ Aggiornare significa: modificare la sezione gia' esistente che descrive l'area t
 
 Quiz interattivo single-page per imparare a riconoscere a colpo d'occhio i sistemi di scrittura del mondo: appare un glifo (hiragana, devanagari, arabo, greco, ecc.) e l'utente sceglie tra quattro opzioni. Quattro modalita': Allenamento libero, Sfida a tempo, Survival, Sfida giornaliera deterministica con griglia emoji condivisibile. Tono estetico: gioco-quiz, dark, palette ambra di default.
 
-Niente backend per ora: tutto in-memory, persistenza via `localStorage` per stato di gioco, lingua UI e preferenze visive. Le aree social (login, profilo pubblico, leaderboard, sfide tra amici) sono stub "In arrivo" in attesa della 1.1.0 con Firebase Auth + Firestore.
+Persistenza dei progressi via `localStorage` per stato di gioco, lingua UI e preferenze visive. Login via Firebase Auth (Email/Password + Google) gia' attivo: l'utente puo' creare un account o continuare in modo anonimo. La sincronizzazione dei progressi nel cloud, profilo pubblico, classifica e sfide tra amici sono ancora stub "In arrivo".
 
 ## Stack
 
@@ -60,6 +60,7 @@ src/
       game/
       glyph-detail/
       home/
+      login/
       onboarding/
       script-detail/
       selection/
@@ -299,8 +300,8 @@ L'app si appoggia a Firebase Auth + Firestore per login e sincronizzazione del p
 
 ### Cosa NON e' ancora collegato
 
-- La pagina `/login` e' ancora `ComingSoon` placeholder. Verra' sostituita da una pagina vera in una PR successiva, che chiamera' `AuthService.signInEmail/signInGoogle`.
-- La sincronizzazione di `state` (campi gioco: streak, played, perScript, ecc.) con Firestore al cambio di `auth.user` non e' ancora implementata. Verra' in una PR dedicata. Per ora `state.account` viene popolato ma i progressi restano in `localStorage`.
+- La sincronizzazione di `state` (campi gioco: streak, played, perScript, ecc.) con Firestore al cambio di `auth.user` non e' ancora implementata. Verra' in una PR dedicata. Per ora `state.account` viene popolato dall'Auth ma i progressi restano in `localStorage`.
+- Le route `/profile`, `/leaderboard`, `/u/:nickname` sono ancora `ComingSoon`. Le PR che le accendono usano gia' lo stato Auth (`AuthService.user()`) come fonte di verita'.
 
 ### Convenzioni
 

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -64,8 +64,15 @@ export const routes: Routes = [
   },
   { path: 'feedback',          canActivate: [onboardedGuard], loadComponent: comingSoon },
 
-  // Aree social: stub fino alla 1.1.0 con Firebase.
-  { path: 'login',             loadComponent: comingSoon },
+  // Pagina di login vera, collegata a Firebase Auth. NO onboardedGuard:
+  // deve essere accessibile anche prima dell'onboarding (es. dal banner della
+  // sezione Impostazioni).
+  {
+    path: 'login',
+    loadComponent: () => import('./features/login/login').then((m) => m.Login),
+  },
+
+  // Aree social ancora stub: profilo pubblico, classifica, sfide tra amici.
   { path: 'profile',           canActivate: [onboardedGuard], loadComponent: comingSoon },
   { path: 'leaderboard',       canActivate: [onboardedGuard], loadComponent: comingSoon },
   { path: 'u/:nickname',       loadComponent: comingSoon },

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -18,6 +18,7 @@ export class App {
   private readonly router = inject(Router);
 
   constructor() {
+
     // Direzione della navigazione corrente, usata dal CSS delle view transitions:
     // se l'utente ha premuto Indietro (browser o app), e' 'back' e il CSS inverte
     // l'asse dello slide; in tutti gli altri casi (link, push imperativo) e' 'forward'.

--- a/src/app/core/firebase/auth.service.ts
+++ b/src/app/core/firebase/auth.service.ts
@@ -56,6 +56,14 @@ export class AuthService {
     return cred.user;
   }
 
+  /**
+   * Flow OAuth Google via popup. Avevamo provato signInWithRedirect per
+   * aggirare i problemi di Cross-Origin-Opener-Policy, ma Firebase non riusciva
+   * a finalizzare il return del redirect su localhost (getRedirectResult
+   * tornava "no redirect pending" anche dopo un'autenticazione riuscita lato
+   * server). Il popup invece e' un flow piu' diretto: signInWithPopup risolve
+   * con il User quando l'utente completa il flow Google.
+   */
   async signInGoogle(): Promise<User> {
     const auth = this.requireAuth();
     const provider = new GoogleAuthProvider();

--- a/src/app/core/state/app-state.service.ts
+++ b/src/app/core/state/app-state.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, computed, effect, inject, signal } from '@angular/core';
+import { Injectable, computed, effect, inject, signal, untracked } from '@angular/core';
 import { AccountInfo, AppState, DEFAULT_STATE } from './types';
 import { AuthService } from '../firebase/auth.service';
 
@@ -45,16 +45,22 @@ export class AppStateService {
     // I campi nickname/avatar restano i valori locali precedenti se l'utente
     // li ha gia' scelti; al primo login da provider OAuth li seedeiamo da
     // displayName / valori default.
+    //
+    // IMPORTANTE: tutte le letture di _state qui dentro devono essere in
+    // untracked(): se le tracciassimo, ogni write a _state rilancerebbe
+    // l'effect, e ogni write nasce dallo spread di un nuovo oggetto, quindi
+    // l'effect si auto-rilancerebbe all'infinito (loop che blocca il tab).
     effect(() => {
       const u = this.auth.user();
       if (u === 'loading') return;
       if (!u) {
-        if (this._state().account) {
+        const hadAccount = untracked(() => this._state().account);
+        if (hadAccount) {
           this._state.update((s) => ({ ...s, account: null }));
         }
         return;
       }
-      const existing = this._state().account;
+      const existing = untracked(() => this._state().account);
       // Se esiste gia' un account locale con lo stesso uid, manteniamo i
       // valori scelti dall'utente (nickname/avatar) e aggiorniamo solo i
       // campi che vengono dall'Auth.

--- a/src/app/features/home/home.css
+++ b/src/app/features/home/home.css
@@ -163,3 +163,87 @@
   color: var(--text-mute);
   opacity: 0.7;
 }
+
+/* Wrapper relativo per ancorare il popover account sotto l'icona trigger. */
+.account-wrap {
+  position: relative;
+}
+
+/* Iniziale del nickname per utente loggato: cerchio accent dentro la btn-icon. */
+.account-initial {
+  display: grid;
+  place-items: center;
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  background: var(--accent);
+  color: var(--accent-contrast);
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 14px;
+}
+
+/* Popover account: sotto l'icona trigger, allineato a destra. Voci come
+   pulsanti pieni, separatore prima del logout, "Esci" colorato danger. */
+.account-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  /* Larghezza adattiva al contenuto: la voce piu' lunga determina la
+     larghezza del popover. min-width per evitare popover troppo stretti
+     quando le voci sono cortissime (es. solo "Esci"). */
+  width: max-content;
+  min-width: 140px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 6px;
+  box-shadow: 0 16px 40px -16px rgba(0, 0, 0, 0.55), 0 0 0 1px rgba(255, 255, 255, 0.02) inset;
+  z-index: 50;
+  animation: account-menu-pop 140ms var(--tx-ease);
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+@keyframes account-menu-pop {
+  from { opacity: 0; transform: translateY(-4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+[data-motion="minimal"] .account-menu {
+  animation: none;
+}
+
+/* Voci del menu: niente icone, solo testo allineato a destra dentro la voce.
+   Risultato: lista snella di azioni, cliccabile su tutta la larghezza. */
+.account-menu-item {
+  appearance: none;
+  display: block;
+  width: 100%;
+  padding: 10px 14px;
+  background: transparent;
+  border: 0;
+  color: var(--text);
+  font: inherit;
+  font-size: 13px;
+  text-align: right;
+  cursor: pointer;
+  border-radius: 8px;
+  transition: background var(--hover-dur) ease;
+}
+.account-menu-item:hover {
+  background: var(--surface-2);
+}
+
+.account-menu-sep {
+  height: 1px;
+  background: var(--border);
+  margin: 4px 6px;
+}
+
+/* "Esci" e' destructive: testo danger, hover con sfondo rosato lieve. */
+.account-menu-item.is-danger {
+  color: var(--danger);
+}
+.account-menu-item.is-danger:hover {
+  background: rgba(251, 113, 133, 0.08);
+}

--- a/src/app/features/home/home.html
+++ b/src/app/features/home/home.html
@@ -1,13 +1,53 @@
 <div class="app-shell">
   <app-bar>
     <app-lang-switch />
-    <button
-      class="btn-icon"
-      [attr.aria-label]="state().account ? 'Account' : i18n.t('profile')"
-      (click)="state().account ? goProfile() : goLogin()"
-    >
-      <app-icon name="user" />
-    </button>
+    <!-- Trigger del menu account in alto a destra. Per gli utenti loggati
+         mostriamo l'iniziale del nickname su sfondo ambra; per gli anonimi
+         l'icona generica user. Il click apre/chiude il popover qui sotto. -->
+    <div class="account-wrap">
+      <button
+        type="button"
+        class="btn-icon account-trigger"
+        [attr.aria-label]="state().account ? 'Account' : i18n.t('profile')"
+        [attr.aria-expanded]="accountMenuOpen()"
+        (click)="toggleAccountMenu($event)"
+      >
+        @if (state().account; as a) {
+          <span class="account-initial">{{ a.nickname.charAt(0).toUpperCase() }}</span>
+        } @else {
+          <app-icon name="user" />
+        }
+      </button>
+
+      @if (accountMenuOpen()) {
+        <div class="account-menu" (click)="$event.stopPropagation()" role="menu">
+          @if (state().account) {
+            <button type="button" class="account-menu-item" role="menuitem"
+                    (click)="closeAccountMenu(); goProfile()">
+              {{ i18n.t('profile') }}
+            </button>
+            <button type="button" class="account-menu-item" role="menuitem"
+                    (click)="closeAccountMenu(); goSettings()">
+              {{ i18n.t('settings') }}
+            </button>
+            <div class="account-menu-sep"></div>
+            <button type="button" class="account-menu-item is-danger" role="menuitem"
+                    (click)="askSignOut()">
+              {{ i18n.t('logout') }}
+            </button>
+          } @else {
+            <button type="button" class="account-menu-item" role="menuitem"
+                    (click)="closeAccountMenu(); goLogin()">
+              {{ i18n.t('login') }}
+            </button>
+            <button type="button" class="account-menu-item" role="menuitem"
+                    (click)="closeAccountMenu(); goSettings()">
+              {{ i18n.t('settings') }}
+            </button>
+          }
+        </div>
+      }
+    </div>
   </app-bar>
 
   <div class="page">
@@ -15,7 +55,7 @@
       <span class="eyebrow">{{ todayLabel() }}</span>
       <h1 class="h1">
         @if (state().account; as a) {
-          {{ i18n.lang() === 'it' ? 'Ciao,' : 'Hi,' }} <span class="home-name">{{ a.nickname }}.</span>
+          {{ i18n.lang() === 'it' ? 'Ciao,' : 'Hi,' }} <span class="home-name">{{ a.nickname }}</span>
         } @else {
           {{ i18n.lang() === 'it' ? 'Ciao,' : 'Hi,' }} <span class="home-name">{{ i18n.lang() === 'it' ? 'lettore.' : 'reader.' }}</span>
         }
@@ -200,5 +240,15 @@
 
   @if (infoOverlay()) {
     <app-info-sheet [title]="infoTitle()" [body]="infoBody()" (close)="closeInfo()" />
+  }
+
+  @if (signOutDialog()) {
+    <app-confirm-dialog
+      [title]="i18n.lang() === 'it' ? 'Sei sicuro di uscire?' : 'Are you sure you want to sign out?'"
+      [confirmLabel]="i18n.t('logout')"
+      [cancelLabel]="i18n.lang() === 'it' ? 'Annulla' : 'Cancel'"
+      (confirmed)="confirmSignOut()"
+      (cancel)="cancelSignOut()"
+    />
   }
 </div>

--- a/src/app/features/home/home.ts
+++ b/src/app/features/home/home.ts
@@ -1,11 +1,13 @@
-import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, HostListener, computed, inject, signal } from '@angular/core';
 import { Router } from '@angular/router';
 import { I18nService } from '../../core/i18n/i18n.service';
 import { AppStateService } from '../../core/state/app-state.service';
+import { AuthService } from '../../core/firebase/auth.service';
 import { ALL_SCRIPT_IDS } from '../../core/data/scripts';
 import { buildQuestion, mulberry32, seedFromDate } from '../../core/data/quiz';
 import { computeBadges } from '../../core/data/badges';
 import { AppBar } from '../../shared/app-bar';
+import { ConfirmDialog } from '../../shared/confirm-dialog';
 import { Icon } from '../../shared/icon';
 import { InfoSheet } from '../../shared/info-sheet';
 import { LangSwitch } from '../../shared/lang-switch';
@@ -15,7 +17,7 @@ type InfoKind = 'streak' | 'accuracy' | 'played' | 'dailyStreak';
 
 @Component({
   selector: 'app-home',
-  imports: [AppBar, Icon, InfoSheet, LangSwitch],
+  imports: [AppBar, ConfirmDialog, Icon, InfoSheet, LangSwitch],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './home.html',
   styleUrl: './home.css',
@@ -24,8 +26,16 @@ export class Home {
   private readonly router = inject(Router);
   protected readonly i18n = inject(I18nService);
   protected readonly appState = inject(AppStateService);
+  private readonly authSvc = inject(AuthService);
 
   protected readonly state = this.appState.state;
+
+  /** Apertura del menu account (popover sotto l'icona in alto a destra). */
+  protected readonly accountMenuOpen = signal(false);
+
+  /** Dialog di conferma logout: aperto dopo aver cliccato "Esci" nel menu,
+   *  evita disconnessioni accidentali. */
+  protected readonly signOutDialog = signal(false);
 
   /** Versione mostrata in fondo alla home. In dev include "dev" e l'hash di commit. */
   protected readonly buildLabel =
@@ -163,5 +173,52 @@ export class Home {
 
   protected goFeedback(): void {
     this.router.navigate(['/feedback']);
+  }
+
+  /** Toggle del popover account; chiude se aperto, apre se chiuso. Lo
+   *  stopPropagation evita che il click-outside listener lo richiuda subito. */
+  protected toggleAccountMenu(e: Event): void {
+    e.stopPropagation();
+    this.accountMenuOpen.update((v) => !v);
+  }
+
+  protected closeAccountMenu(): void {
+    this.accountMenuOpen.set(false);
+  }
+
+  /** Apre il dialog di conferma logout. Chiude il menu in modo che la modale
+   *  resti l'unico elemento in primo piano. */
+  protected askSignOut(): void {
+    this.closeAccountMenu();
+    this.signOutDialog.set(true);
+  }
+
+  protected cancelSignOut(): void {
+    this.signOutDialog.set(false);
+  }
+
+  /** Conferma logout: Firebase signOut, l'effect in AppStateService azzera
+   *  state.account in automatico. Restiamo sulla home con la modale chiusa. */
+  protected async confirmSignOut(): Promise<void> {
+    this.signOutDialog.set(false);
+    try {
+      await this.authSvc.signOut();
+    } catch {
+      // Fallimenti rari (es. rete offline durante la revoca): sessione locale
+      // viene comunque rimossa.
+    }
+  }
+
+  /** Click ovunque sul documento chiude il popover. Il bottone trigger ha
+   *  stopPropagation quindi non si auto-richiude. */
+  @HostListener('document:click')
+  protected onDocClick(): void {
+    if (this.accountMenuOpen()) this.closeAccountMenu();
+  }
+
+  /** Escape chiude il popover (accessibilita'). */
+  @HostListener('window:keydown.escape')
+  protected onEscape(): void {
+    if (this.accountMenuOpen()) this.closeAccountMenu();
   }
 }

--- a/src/app/features/login/login.css
+++ b/src/app/features/login/login.css
@@ -1,0 +1,195 @@
+/* La pagina /login si presenta come una colonna stretta centrata
+   verticalmente, simil-modal. La AppBar in alto serve solo da chrome con il
+   tasto Indietro: non c'e' titolo, il titolo vero ("Crea il tuo profilo")
+   sta dentro la hero della card. */
+.login-page {
+  min-height: calc(100dvh - 80px);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.login-card {
+  width: 100%;
+  max-width: 400px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.login-hero {
+  text-align: center;
+  margin-bottom: 14px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+.login-title {
+  margin-top: 18px;
+}
+.login-sub {
+  font-size: 14px;
+  margin-top: 8px;
+  max-width: 320px;
+}
+
+/* Banner visibile solo se firebase.config.ts e' ancora a PLACEHOLDER. Aiuta a
+   capire perche' i bottoni di login non funzionano in build di sviluppo
+   non configurate. */
+.login-disabled-banner {
+  background: rgba(251, 191, 36, 0.08);
+  border: 1px solid rgba(251, 191, 36, 0.35);
+  color: var(--warm);
+  border-radius: 12px;
+  padding: 12px 14px;
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+/* Stato "gia' loggato": l'app-level effect ti porta in home, ma in attesa
+   mostriamo conferma esplicita + bottone fallback. Card centrata. */
+.login-already-in {
+  background: rgba(52, 211, 153, 0.06);
+  border: 1px solid rgba(52, 211, 153, 0.3);
+  border-radius: 14px;
+  padding: 18px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.login-already-in-title {
+  font-size: 16px;
+  font-weight: 500;
+}
+.login-already-in-nick {
+  color: var(--accent);
+  font-weight: 600;
+}
+.login-already-in-sub {
+  font-size: 13px;
+  margin: 0 0 6px;
+}
+
+/* Bottone provider Google in stile "white card on dark". L'icona e' un SVG
+   inline con i colori Google ufficiali, non un'icona del nostro set. */
+.provider-btn {
+  gap: 10px;
+  font-weight: 500;
+}
+.provider-google {
+  background: #ffffff;
+  color: #18181b;
+  border: 1px solid var(--border);
+}
+.provider-google:hover:not(:disabled) {
+  background: #f4f4f5;
+}
+.provider-google:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.login-divider {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 6px 0 2px;
+  color: var(--text-mute);
+  font-size: 11px;
+  font-family: var(--font-mono);
+  letter-spacing: 0.12em;
+}
+.login-divider::before,
+.login-divider::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: var(--border);
+}
+
+.login-form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.login-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.login-field-label {
+  font-size: 12px;
+  color: var(--text-dim);
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+}
+.login-field-hint {
+  font-size: 11px;
+}
+
+/* Input di testo riusabile per form di questa pagina. Le altre pagine
+   dell'app non hanno form, quindi per ora questa classe vive scoped qui. Se
+   in futuro nasce un secondo form (impostazioni nickname, feedback), la si
+   promuove a styles.css globale. */
+.input-field {
+  width: 100%;
+  padding: 13px 14px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  color: var(--text);
+  font-size: 14px;
+  font-family: inherit;
+  outline: none;
+  box-sizing: border-box;
+  transition: border-color var(--hover-dur) ease;
+}
+.input-field:focus {
+  border-color: var(--accent);
+}
+
+.login-error {
+  margin: 0;
+  padding: 10px 12px;
+  background: rgba(251, 113, 133, 0.08);
+  border: 1px solid rgba(251, 113, 133, 0.35);
+  color: var(--danger);
+  border-radius: 10px;
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.login-submit {
+  margin-top: 4px;
+}
+
+.login-hint {
+  font-size: 11px;
+  text-align: center;
+  margin: 8px 0 0;
+  line-height: 1.4;
+}
+
+/* Link "Continua senza account" in fondo, stile testuale come una nav-btn ma
+   centrato e senza bordo. */
+.login-anon {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  color: var(--text-dim);
+  font: inherit;
+  font-size: 13px;
+  margin: 14px auto 0;
+  padding: 8px 12px;
+  cursor: pointer;
+  border-radius: 8px;
+  transition: color var(--hover-dur) ease, background var(--hover-dur) ease;
+}
+.login-anon:hover {
+  color: var(--text);
+  background: var(--surface-2);
+}

--- a/src/app/features/login/login.html
+++ b/src/app/features/login/login.html
@@ -1,0 +1,136 @@
+<div class="app-shell">
+  <app-bar [canBack]="true" (back)="goBack()" (goHome)="goHome()" />
+
+  <div class="page login-page">
+    <div class="login-card">
+      <div class="login-hero">
+        <app-logo size="lg" />
+        <h1 class="h1 login-title">
+          {{ i18n.lang() === 'it' ? 'Accedi' : 'Sign in' }}
+        </h1>
+        <p class="muted login-sub">
+          {{ i18n.lang() === 'it'
+            ? 'Rientra nel tuo profilo o creane uno: salvi i progressi su tutti i tuoi dispositivi.'
+            : 'Sign back in or create a profile: save your progress across all your devices.' }}
+        </p>
+      </div>
+
+      @if (!auth.enabled) {
+        <div class="login-disabled-banner">
+          {{ i18n.lang() === 'it'
+            ? 'Firebase non e\' ancora configurato in questa build. Completa i passi in CLAUDE.md > Firebase per attivare il login.'
+            : 'Firebase is not configured in this build. Follow the steps in CLAUDE.md > Firebase to enable login.' }}
+        </div>
+      } @else if (isAuthenticated()) {
+        <!-- Sei gia' loggato: l'app-level effect ti portera' a /home a breve.
+             Mostriamo intanto stato esplicito + bottone Vai alla home come
+             fallback nel caso il redirect automatico tardi (ad es. un browser
+             che blocca le navigazioni programmatic dopo un redirect OAuth). -->
+        <div class="login-already-in">
+          <div class="login-already-in-title">
+            {{ i18n.lang() === 'it' ? 'Sei dentro!' : 'You\'re in!' }}
+            @if (currentNickname()) {
+              {{ ' ' }}
+              <span class="login-already-in-nick">{{ currentNickname() }}</span>
+            }
+          </div>
+          <p class="muted login-already-in-sub">
+            {{ i18n.lang() === 'it' ? 'Ti porto alla home.' : 'Taking you home.' }}
+          </p>
+          <button type="button" class="btn btn-primary btn-block" (click)="goHome()">
+            {{ i18n.lang() === 'it' ? 'Vai alla home' : 'Go to home' }}
+          </button>
+        </div>
+      }
+
+      @if (!isAuthenticated()) {
+      <!-- Provider sociali in cima: per ora solo Google. Apple richiede un
+           Apple Developer account e va abilitato lato Firebase Console, quindi
+           lo lasciamo fuori finche' non serve davvero. -->
+      <button
+        type="button"
+        class="btn btn-block provider-btn provider-google"
+        [disabled]="busy() || !auth.enabled"
+        (click)="submitGoogle()"
+      >
+        <svg width="16" height="16" viewBox="0 0 24 24" aria-hidden="true">
+          <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
+          <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.99.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
+          <path fill="#FBBC05" d="M5.84 14.1c-.22-.66-.35-1.36-.35-2.1s.13-1.44.35-2.1V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l3.66-2.83z"/>
+          <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.83C6.71 7.31 9.14 5.38 12 5.38z"/>
+        </svg>
+        {{ i18n.lang() === 'it' ? 'Continua con Google' : 'Continue with Google' }}
+      </button>
+
+      <div class="login-divider">
+        <span>{{ i18n.lang() === 'it' ? 'OPPURE' : 'OR' }}</span>
+      </div>
+
+      <!-- Form email unificato: un solo bottone che fa login se l'account
+           esiste, registrazione se no. Logica in submitEmail(). Per Firebase
+           la password deve essere lunga almeno 6 caratteri. -->
+      <form class="login-form" (ngSubmit)="submitEmail()">
+        <label class="login-field">
+          <span class="login-field-label">Email</span>
+          <input
+            type="email"
+            autocomplete="email"
+            class="input-field"
+            placeholder="tu@esempio.it"
+            [ngModel]="email()"
+            (ngModelChange)="setEmail($event)"
+            name="email"
+            required
+          />
+        </label>
+
+        <label class="login-field">
+          <span class="login-field-label">
+            {{ i18n.lang() === 'it' ? 'Password' : 'Password' }}
+            <span class="muted login-field-hint">
+              {{ i18n.lang() === 'it' ? 'almeno 6 caratteri' : 'at least 6 characters' }}
+            </span>
+          </span>
+          <input
+            type="password"
+            autocomplete="current-password"
+            class="input-field"
+            placeholder="••••••"
+            [ngModel]="password()"
+            (ngModelChange)="setPassword($event)"
+            name="password"
+            minlength="6"
+            required
+          />
+        </label>
+
+        @if (error(); as e) {
+          <p class="login-error" role="alert">{{ e }}</p>
+        }
+
+        <button
+          type="submit"
+          class="btn btn-primary btn-block login-submit"
+          [disabled]="!canSubmit() || !auth.enabled"
+        >
+          @if (busy()) {
+            {{ i18n.lang() === 'it' ? 'Attendere…' : 'Working…' }}
+          } @else {
+            {{ i18n.lang() === 'it' ? 'Continua con email' : 'Continue with email' }}
+          }
+        </button>
+
+        <p class="muted login-hint">
+          {{ i18n.lang() === 'it'
+            ? 'Se non hai ancora un account, viene creato in automatico.'
+            : 'If you don\'t have an account yet, one is created automatically.' }}
+        </p>
+      </form>
+
+      <button type="button" class="login-anon" (click)="continueAnonymous()">
+        {{ i18n.lang() === 'it' ? 'Continua senza account' : 'Continue without account' }}
+      </button>
+      }
+    </div>
+  </div>
+</div>

--- a/src/app/features/login/login.ts
+++ b/src/app/features/login/login.ts
@@ -1,0 +1,206 @@
+import { ChangeDetectionStrategy, Component, computed, effect, inject, signal } from '@angular/core';
+import { Location } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { Router } from '@angular/router';
+import { I18nService } from '../../core/i18n/i18n.service';
+import { AuthService } from '../../core/firebase/auth.service';
+import { AppStateService } from '../../core/state/app-state.service';
+import { AppBar } from '../../shared/app-bar';
+import { Logo } from '../../shared/logo';
+
+@Component({
+  selector: 'app-login',
+  imports: [AppBar, Logo, FormsModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './login.html',
+  styleUrl: './login.css',
+})
+export class Login {
+  private readonly router = inject(Router);
+  private readonly location = inject(Location);
+  protected readonly i18n = inject(I18nService);
+  protected readonly auth = inject(AuthService);
+  protected readonly appState = inject(AppStateService);
+
+  protected readonly email = signal('');
+  protected readonly password = signal('');
+  protected readonly busy = signal(false);
+  protected readonly error = signal<string | null>(null);
+
+  /** Se siamo gia' autenticati: tornare al rendering qui dentro significa che
+   *  ci siamo arrivati dal redirect Google (o che eravamo gia' loggati e
+   *  abbiamo riaperto /login). L'app-level effect ci portera' a /home, ma in
+   *  attesa mostriamo un banner di stato esplicito + un bottone "Vai alla
+   *  home" cosi' l'utente non sente che la pagina e' rotta se il redirect
+   *  automatico fosse lento per qualche motivo. */
+  protected readonly isAuthenticated = computed(() => {
+    const u = this.auth.user();
+    return u !== null && u !== 'loading';
+  });
+  protected readonly currentNickname = computed(
+    () => this.appState.state().account?.nickname ?? '',
+  );
+
+  constructor() {
+    // Login e' montato solo quando il browser e' su /login: niente race con il
+    // router. Appena auth.user diventa un User autenticato, navighiamo a /home.
+    // Questo copre tutti gli ingressi: completato un signInWithPopup, sessione
+    // ripresa al caricamento pagina, o utente che riapre /login per sbaglio
+    // mentre era gia' loggato.
+    effect(() => {
+      const u = this.auth.user();
+      if (u && u !== 'loading') {
+        this.router.navigate(['/home']);
+      }
+    });
+  }
+
+  protected goHome(): void {
+    this.router.navigate(['/home']);
+  }
+
+  protected readonly emailValid = computed(() =>
+    /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(this.email()),
+  );
+  protected readonly passwordValid = computed(() => this.password().length >= 6);
+  protected readonly canSubmit = computed(
+    () => this.emailValid() && this.passwordValid() && !this.busy(),
+  );
+
+  /** Per [(ngModel)] al template, perche' i signal non hanno ancora il binding
+   *  diretto. Patterns identici per email + password. */
+  protected setEmail(v: string): void {
+    this.email.set(v);
+    if (this.error()) this.error.set(null);
+  }
+  protected setPassword(v: string): void {
+    this.password.set(v);
+    if (this.error()) this.error.set(null);
+  }
+
+  /**
+   * Flow unificato login/registrazione (stile Google one-tap):
+   *  1. Prova prima signIn (caso piu' frequente: utente che torna).
+   *  2. Se Firebase risponde "account non esistente" / "credenziali invalide",
+   *     tenta signUp. Se anche signUp fallisce per "email gia' in uso", allora
+   *     l'account esiste davvero ma la password e' sbagliata: mostriamo questo
+   *     errore specifico.
+   *  3. Qualunque altro errore di signIn (rate limit, network, ecc.) viene
+   *     propagato direttamente senza fallback.
+   */
+  protected async submitEmail(): Promise<void> {
+    if (!this.canSubmit()) return;
+    this.busy.set(true);
+    this.error.set(null);
+    const email = this.email().trim();
+    const password = this.password();
+    try {
+      try {
+        await this.auth.signInEmail(email, password);
+      } catch (signInErr: unknown) {
+        const code = (signInErr as { code?: string })?.code ?? '';
+        // Firebase non distingue piu' "utente non esistente" da "password
+        // sbagliata" (entrambi → auth/invalid-credential), quindi proviamo
+        // signUp solo per i codici che potrebbero indicare account assente.
+        const looksLikeUnknownAccount =
+          code === 'auth/invalid-credential' ||
+          code === 'auth/user-not-found' ||
+          code === 'auth/wrong-password';
+        if (!looksLikeUnknownAccount) throw signInErr;
+        try {
+          await this.auth.signUpEmail(email, password);
+        } catch (signUpErr: unknown) {
+          // Se signUp fallisce con "email in uso", l'account esiste e la
+          // password e' sbagliata: rilanciamo come "credenziali errate".
+          const upCode = (signUpErr as { code?: string })?.code ?? '';
+          if (upCode === 'auth/email-already-in-use') throw signInErr;
+          throw signUpErr;
+        }
+      }
+      // Navigazione gestita dall'effect del costruttore: l'auth state cambia e
+      // l'effect ci porta a /home. Niente navigate qui sotto per evitare la
+      // doppia chiamata che generava AbortError "Transition was skipped".
+    } catch (e: unknown) {
+      this.error.set(this.translateError(e));
+    } finally {
+      this.busy.set(false);
+    }
+  }
+
+  /**
+   * Google sign-in via popup. signInWithPopup risolve con il User quando
+   * l'utente completa il flow su accounts.google.com. Non navigamo qui: ci
+   * pensa l'effect del costruttore quando auth.user cambia, evitando la
+   * doppia navigate.
+   *
+   * Nota: il signInWithPopup emette warning innocui in console
+   * ("Cross-Origin-Opener-Policy policy would block the window.closed call")
+   * a causa del polling che Firebase fa sullo stato del popup. L'auth
+   * funziona comunque via postMessage, i warning sono solo rumore.
+   */
+  protected async submitGoogle(): Promise<void> {
+    this.busy.set(true);
+    this.error.set(null);
+    try {
+      await this.auth.signInGoogle();
+    } catch (e: unknown) {
+      this.error.set(this.translateError(e));
+    } finally {
+      this.busy.set(false);
+    }
+  }
+
+  protected continueAnonymous(): void {
+    this.router.navigate(['/home']);
+  }
+
+  protected goBack(): void {
+    this.location.back();
+  }
+
+  /** Mappa gli errori Firebase ai messaggi user-facing in lingua corrente. Gli
+   *  error code Firebase sono stringhe stabili tipo "auth/wrong-password". */
+  private translateError(e: unknown): string {
+    const isIt = this.i18n.lang() === 'it';
+    const code = (e as { code?: string })?.code ?? '';
+    switch (code) {
+      case 'auth/invalid-email':
+        return isIt ? 'Email non valida.' : 'Invalid email.';
+      case 'auth/email-already-in-use':
+        return isIt
+          ? 'Questa email e\' gia\' registrata: prova ad accedere invece di crearne una nuova.'
+          : 'This email is already registered: try signing in instead.';
+      case 'auth/weak-password':
+        return isIt
+          ? 'La password deve essere lunga almeno 6 caratteri.'
+          : 'Password must be at least 6 characters long.';
+      case 'auth/invalid-credential':
+      case 'auth/wrong-password':
+      case 'auth/user-not-found':
+        return isIt
+          ? 'Email o password non corrette.'
+          : 'Email or password is incorrect.';
+      case 'auth/too-many-requests':
+        return isIt
+          ? 'Troppi tentativi in poco tempo: riprova fra qualche minuto.'
+          : 'Too many attempts: please try again in a few minutes.';
+      case 'auth/popup-closed-by-user':
+      case 'auth/cancelled-popup-request':
+        return isIt
+          ? 'Accesso annullato.'
+          : 'Sign-in cancelled.';
+      case 'auth/popup-blocked':
+        return isIt
+          ? 'Il browser ha bloccato il popup. Abilitalo per questo sito e riprova.'
+          : 'Your browser blocked the popup. Enable it for this site and try again.';
+      case 'auth/network-request-failed':
+        return isIt
+          ? 'Niente connessione: controlla la rete e riprova.'
+          : 'No connection: check your network and try again.';
+      default:
+        return isIt
+          ? 'Qualcosa non ha funzionato. Riprova.'
+          : 'Something went wrong. Please try again.';
+    }
+  }
+}

--- a/src/app/features/settings/settings.css
+++ b/src/app/features/settings/settings.css
@@ -89,36 +89,8 @@
   line-height: 1.4;
 }
 
-.seg {
-  display: flex;
-  gap: 4px;
-  padding: 4px;
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: 12px;
-}
-.seg-btn {
-  flex: 1;
-  height: 36px;
-  border: 0;
-  border-radius: 8px;
-  background: transparent;
-  color: var(--text-dim);
-  font: inherit;
-  font-size: 13px;
-  font-weight: 500;
-  cursor: pointer;
-  transition:
-    background var(--hover-dur) ease,
-    color var(--hover-dur) ease;
-}
-.seg-btn:hover:not(.is-active) {
-  background: var(--surface-2);
-}
-.seg-btn.is-active {
-  background: var(--surface-3);
-  color: var(--text);
-}
+/* .seg + .seg-btn ora vivono in src/styles.css globale, riusabili da settings e
+   login (toggle Accedi/Crea account). Qui niente. */
 
 .swatches {
   display: flex;

--- a/src/app/features/settings/settings.html
+++ b/src/app/features/settings/settings.html
@@ -13,8 +13,8 @@
           <span class="account-name">{{ a.nickname }}</span>
           <span class="account-sub mono">{{ a.email }}</span>
         </div>
-        <button class="nav-btn" type="button" (click)="goProfile()">
-          {{ i18n.t('profile') }}
+        <button class="nav-btn account-logout" type="button" (click)="signOut()">
+          {{ i18n.t('logout') }}
         </button>
       } @else {
         <span class="account-avatar">

--- a/src/app/features/settings/settings.ts
+++ b/src/app/features/settings/settings.ts
@@ -14,6 +14,7 @@ import {
 import { AppBar } from '../../shared/app-bar';
 import { Icon } from '../../shared/icon';
 import { APP_VERSION, BUILD_CONTEXT, BUILD_SHA } from '../../core/build-info';
+import { AuthService } from '../../core/firebase/auth.service';
 
 @Component({
   selector: 'app-settings',
@@ -27,6 +28,7 @@ export class Settings {
   private readonly location = inject(Location);
   protected readonly i18n = inject(I18nService);
   protected readonly appState = inject(AppStateService);
+  private readonly authSvc = inject(AuthService);
 
   protected readonly state = this.appState.state;
 
@@ -83,6 +85,20 @@ export class Settings {
   }
   protected replayOnboarding(): void {
     this.router.navigate(['/onboarding']);
+  }
+
+  /** Logout: Firebase signOut + l'effect in AppStateService azzera state.account
+   *  in automatico. Dopo il signOut, redirige a /home perche' la pagina
+   *  impostazioni e' un posto un po' tecnico in cui restare: con la sessione
+   *  chiusa ha piu' senso atterrare nel posto neutro principale. */
+  protected async signOut(): Promise<void> {
+    try {
+      await this.authSvc.signOut();
+    } catch {
+      // Fallimenti rari (es. rete offline durante la revoca del token): la
+      // sessione lato client viene rimossa comunque, va bene cosi'.
+    }
+    this.router.navigate(['/home']);
   }
 
   protected resetProgress(): void {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1170,6 +1170,40 @@ button {
   100% { transform: scale(1) rotate(0); }
 }
 
+/* Segmented control globale: una row di pulsanti che fa da toggle (3-state in
+   Settings per Animazioni / Accessibilita' / Lingua, 2-state in Login per
+   Accedi/Crea account). Tutti i toggle dell'app condividono questo look. */
+.seg {
+  display: flex;
+  gap: 4px;
+  padding: 4px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+}
+.seg-btn {
+  flex: 1;
+  height: 36px;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text-dim);
+  font: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition:
+    background var(--hover-dur) ease,
+    color var(--hover-dur) ease;
+}
+.seg-btn:hover:not(.is-active) {
+  background: var(--surface-2);
+}
+.seg-btn.is-active {
+  background: var(--surface-3);
+  color: var(--text);
+}
+
 /* Home: badges teaser card */
 .badges-teaser {
   display: grid;


### PR DESCRIPTION
Da questa PR puoi accedere all'app: c'e' una vera pagina di login al posto del placeholder di prima, e l'app riconosce quando rientri. Email/password e Google vanno entrambi.

Come funziona dal punto di vista di chi gioca. Dall'icona in alto a destra della home si apre un menu snello: se non sei mai entrato vedi Accedi e Impostazioni; se sei dentro vedi Profilo, Impostazioni e Esci in rosso, con conferma prima del logout per evitare disconnessioni accidentali. La pagina /login ha logo grande, due strade per accedere (Continua con Google, Continua con email), e un link Continua senza account se preferisci giocare anonimo.

Email funziona uguale per chi rientra e per chi e' nuovo: stesso bottone, Firebase prova login e se l'account non c'e' lo crea sul momento. Niente toggle Accedi/Crea account. Sotto al bottone una nota muted "Se non hai ancora un account, viene creato in automatico" rassicura chi e' alla prima volta. Le password sono validate (>= 6 caratteri) e gli errori sono tradotti in italiano: "Email o password non corrette", "Email non valida", "Troppi tentativi", "Niente connessione", e cosi' via.

Google passa per un popup di Google (signInWithPopup): si apre la finestrella ufficiale, scegli account, conferma, torni dentro. Avevamo provato signInWithRedirect ma su localhost Firebase non finalizzava il redirect; col popup va liscio. Restano dei console warning innocui ("Cross-Origin-Opener-Policy policy would block the window.closed call") che vengono dal polling interno di Firebase e non interferiscono col login: l'auth completa via postMessage.

Anche dalle impostazioni puoi uscire (o accedere se anonimo): la card account in cima riflette lo stesso stato del menu in home, sono sincronizzati attraverso state.account.

Sotto al cofano. AuthService espone signal user (User | null | 'loading') e metodi signInEmail/signUpEmail/signInGoogle/signOut. AppStateService osserva auth.user via effect e popola state.account in automatico al cambio di stato: nickname seedato da displayName (se Google) o dalla parte prima della chiocciola (se email), avatar 0 di default. Tutte le letture di _state dentro l'effect usano untracked() per evitare un loop infinito di rerun che bloccava il tab (root cause del SIGILL crash che avevamo riscontrato). Le classi .seg e .seg-btn della pagina impostazioni sono state spostate in src/styles.css globale, cosi' anche la pagina login le riusa per i toggle.

Niente sync su Firestore in questa PR: state.account vive in localStorage come prima, solo che ora viene riempito automaticamente quando ti logghi. La sincronizzazione dei progressi (streak, partite, perScript, traguardi) e' il prossimo step.