### PR TITLE
feat(firebase): sincronizza i progressi in cloud quando sei loggato

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -295,13 +295,30 @@ L'app si appoggia a Firebase Auth + Firestore per login e sincronizzazione del p
 - `src/app/core/firebase/firebase.config.ts`: oggetto config pubblico (committato come placeholder, da riempire).
 - `src/app/core/firebase/firebase.ts`: `ensureFirebaseApp()` inizializza l'app idempotente; ritorna `null` se config = PLACEHOLDER (modalita' offline-only).
 - `src/app/core/firebase/auth.service.ts`: `AuthService` con signal `user` (`User | null | 'loading'`), `enabled` (boolean), metodi `signInEmail/signUpEmail/signInGoogle/signOut`. Quando `enabled === false` i metodi rigettano con `AuthDisabledError`.
+- `src/app/core/firebase/user-doc.service.ts`: `UserDocService` che sincronizza lo stato di gioco con `/users/{uid}` su Firestore quando l'utente e' loggato. Bootstrap-attivato (inject dummy in `App`). All'auth.user che diventa autenticato fa max-merge tra locale e cloud; ad ogni cambio di state mentre loggato, push debounced di 1s. Usa `firebase/firestore/lite` (no real-time, no offline persistence) per tenere il bundle sotto i 500kB.
 - `AppStateService` si abbona al signal `auth.user` via `effect`: a ogni cambio di stato Auth, riflette in `state.account` (uid, email, nickname seedato da `displayName` per Google, avatar 0 di default).
-- `firestore.rules`, `firebase.json`, `.firebaserc` alla root: config per `firebase deploy`. Schema corrente: `/users/{uid}` (stato gioco + anagrafica) e `/nicknames/{nick}` (indice unicita').
+- `firestore.rules`, `firebase.json`, `.firebaserc` alla root: config per `firebase deploy`. Schema corrente: `/users/{uid}` (stato gioco + anagrafica) e `/nicknames/{nick}` (indice unicita', non ancora popolato).
+
+### Cosa viene sincronizzato in cloud
+
+Quando l'utente e' loggato, `/users/{uid}` ospita:
+- `nickname`, `avatar`, `email`, `provider`, `joinedAt`, `updatedAt`
+- Contatori cumulativi: `streak`, `bestStreak`, `played`, `correctAnswers`, `accuracy`
+- `perScript: {[scriptId]: {tries, correct}}` (max-merge per scrittura tra device)
+- Sfida giornaliera: `dailyDone`, `dailyDoneStamp`, `dailyScore`, `dailyStreak`, `dailyHistory[]`
+
+NON sincronizzato (resta per device in `localStorage`): tutte le preferenze UI (`accent`, `motion`, `colorblind`, `sound`, `haptics`, `showCodepoint`), la selezione delle scritture (`selected`), e i flag di sessione (`hintsLeft`, `shownFirstWrong`, `onboarded`). Idea: ti ritrovi i progressi su un altro telefono, ma puoi avere un tema diverso senza che si propaghi.
+
+### Conflict resolution
+
+Al login iniziale, `UserDocService` legge il doc cloud e fa **max-merge** per i contatori cumulativi: cosi' se hai giocato su due device offline, accumuli i progressi su entrambi senza perderli. Per la giornaliera vince lo stamp piu' recente; `dailyHistory` viene unita per `day` (preferisce score piu' alto). Per `nickname`/`avatar` vince il cloud (sono scelte esplicite dell'utente).
+
+Le scritture successive durante la sessione fanno **full overwrite** del documento (con `setDoc({merge: true})` ma a livello field-shallow), perche' dopo il merge iniziale lo stato locale e' la fonte di verita' fino al prossimo login.
 
 ### Cosa NON e' ancora collegato
 
-- La sincronizzazione di `state` (campi gioco: streak, played, perScript, ecc.) con Firestore al cambio di `auth.user` non e' ancora implementata. Verra' in una PR dedicata. Per ora `state.account` viene popolato dall'Auth ma i progressi restano in `localStorage`.
-- Le route `/profile`, `/leaderboard`, `/u/:nickname` sono ancora `ComingSoon`. Le PR che le accendono usano gia' lo stato Auth (`AuthService.user()`) come fonte di verita'.
+- Le route `/profile`, `/leaderboard`, `/u/:nickname` sono ancora `ComingSoon`. Le PR che le accendono usano gia' lo stato Auth (`AuthService.user()`) come fonte di verita' e i progressi cloud da `/users/{uid}`.
+- Unicita' del nickname via `/nicknames/{nick}` non ancora applicata: il nickname viene seedato e basta, niente UI per cambiarlo (la pagina /profile vera lo permettera').
 
 ### Convenzioni
 

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -2,6 +2,7 @@ import { ChangeDetectionStrategy, Component, effect, inject } from '@angular/cor
 import { Title } from '@angular/platform-browser';
 import { NavigationStart, Router, RouterOutlet } from '@angular/router';
 import { AppStateService } from './core/state/app-state.service';
+import { UserDocService } from './core/firebase/user-doc.service';
 import { ACCENT_PALETTES } from './core/state/types';
 import { BUILD_CONTEXT } from './core/build-info';
 
@@ -16,6 +17,9 @@ export class App {
   private readonly appState = inject(AppStateService);
   private readonly title = inject(Title);
   private readonly router = inject(Router);
+  /** Inject solo per bootstrap: il servizio si auto-attiva via effect su
+   *  auth.user e su state. Non lo usiamo direttamente qui. */
+  private readonly userDoc = inject(UserDocService);
 
   constructor() {
 

--- a/src/app/core/firebase/user-doc.service.ts
+++ b/src/app/core/firebase/user-doc.service.ts
@@ -1,0 +1,321 @@
+import { Injectable, effect, inject, untracked } from '@angular/core';
+import { User } from 'firebase/auth';
+// Usiamo la build "lite" di Firestore (firebase/firestore/lite): supporta
+// getDoc/setDoc/doc/serverTimestamp ma non onSnapshot ne' persistenza offline,
+// ed e' molto piu' leggera dell'SDK completo. Ci basta perche' il sync e'
+// lazy (solo al login + debounced writes).
+import {
+  Firestore,
+  doc,
+  getDoc,
+  getFirestore,
+  serverTimestamp,
+  setDoc,
+} from 'firebase/firestore/lite';
+import { ensureFirebaseApp } from './firebase';
+import { AuthService } from './auth.service';
+import { AppStateService } from '../state/app-state.service';
+import { AppState, DailyHistoryEntry, PerScriptStat } from '../state/types';
+
+/**
+ * Sincronizza lo stato di gioco con Firestore quando l'utente e' loggato.
+ *
+ * - All'auth.user che diventa autenticato: legge /users/{uid}, fa max-merge
+ *   coi contatori cumulativi locali, salva lo stato mergiato sia in locale che
+ *   in cloud.
+ * - Mentre l'utente e' loggato: scrive in cloud ad ogni cambio di state, con
+ *   debounce di 1 secondo (per non spammare Firestore su sequenze di update
+ *   rapide tipo "20 risposte di fila in 60 secondi").
+ * - Al logout: smette di scrivere. Lo stato locale resta com'e' per il
+ *   prossimo utente anonimo che vuole giocare offline.
+ *
+ * Le preferenze UI (accent, motion, colorblind, sound, haptics, showCodepoint,
+ * selected scripts, hintsLeft, shownFirstWrong, onboarded) NON vengono
+ * sincronizzate: sono scelte per-dispositivo. Su un nuovo telefono ti ritrovi
+ * i progressi, ma puoi mettere accent diverso senza che si propaghi.
+ */
+@Injectable({ providedIn: 'root' })
+export class UserDocService {
+  private readonly auth = inject(AuthService);
+  private readonly appState = inject(AppStateService);
+  private readonly db: Firestore | null;
+
+  /** Uid della sessione attualmente in sync. Quando cambia (login / logout)
+   *  riarmiamo le scritture e annulliamo i debounce precedenti. */
+  private currentUid: string | null = null;
+  /** True mentre stiamo applicando il merge iniziale dal cloud sul locale.
+   *  Necessario per evitare che il push debounced rimandi al cloud lo stesso
+   *  valore appena ricevuto. */
+  private applyingMerge = false;
+  private debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor() {
+    const app = ensureFirebaseApp();
+    this.db = app ? getFirestore(app) : null;
+    if (!this.db) return;
+
+    // Reagisce ai cambi di auth.user: al login fa il merge iniziale, al logout
+    // ferma il timer di push. Il merge e' sincrono in effetto (apre la richiesta
+    // di rete ma non blocca l'effect): durante il fetch da Firestore lo stato
+    // locale resta usabile come sempre.
+    effect(() => {
+      const u = this.auth.user();
+      if (u === 'loading') return;
+      if (!u) {
+        this.currentUid = null;
+        if (this.debounceTimer) {
+          clearTimeout(this.debounceTimer);
+          this.debounceTimer = null;
+        }
+        return;
+      }
+      if (this.currentUid !== u.uid) {
+        this.currentUid = u.uid;
+        // Fire-and-forget: errori loggati ma non bloccano l'app.
+        void this.onLogin(u);
+      }
+    });
+
+    // Reagisce ai cambi di state mentre c'e' un utente loggato. La lettura di
+    // auth.user e' untracked: l'effect deve dipendere SOLO dallo state, non
+    // dall'auth (che viene gestito dall'altro effect sopra).
+    effect(() => {
+      const s = this.appState.state();
+      const u = untracked(() => this.auth.user());
+      if (!u || u === 'loading') return;
+      if (this.applyingMerge) return;
+      this.schedulePush(u.uid, s);
+    });
+  }
+
+  /** Merge iniziale tra cloud e locale. Crea il documento se non esiste. */
+  private async onLogin(user: User): Promise<void> {
+    if (!this.db) return;
+    const ref = doc(this.db, 'users', user.uid);
+    try {
+      const snap = await getDoc(ref);
+      if (!snap.exists()) {
+        // Primo accesso assoluto per questo account: cloud non sa niente,
+        // scriviamo lo stato locale corrente come "punto zero".
+        const local = this.appState.state();
+        await setDoc(
+          ref,
+          {
+            ...toCloudShape(local, user),
+            joinedAt: serverTimestamp(),
+            updatedAt: serverTimestamp(),
+          },
+          { merge: true },
+        );
+        return;
+      }
+      // Documento esistente: max-merge per i contatori, "cloud vince" per
+      // nickname e avatar (l'utente potrebbe averli editati su un altro
+      // dispositivo). Applichiamo il risultato sul locale.
+      const cloud = snap.data() as CloudUserDoc;
+      const local = this.appState.state();
+      const merged = mergeStates(local, cloud);
+      this.applyingMerge = true;
+      try {
+        this.appState.patch(() => merged);
+      } finally {
+        // L'applyingMerge resta true finche' il microtask termina cosi'
+        // l'effect di push non si attiva sulla scrittura derivante dal merge.
+        queueMicrotask(() => {
+          this.applyingMerge = false;
+        });
+      }
+      // Riallinea il cloud allo stato mergiato (cosi' il cloud accumula i
+      // progressi accumulati offline su questo dispositivo).
+      await setDoc(
+        ref,
+        { ...toCloudShape(merged, user), updatedAt: serverTimestamp() },
+        { merge: true },
+      );
+    } catch (e) {
+      console.warn('[firestore] sync merge error:', e);
+    }
+  }
+
+  private schedulePush(uid: string, state: AppState): void {
+    if (this.debounceTimer) clearTimeout(this.debounceTimer);
+    this.debounceTimer = setTimeout(() => {
+      void this.pushNow(uid, state);
+    }, 1000);
+  }
+
+  private async pushNow(uid: string, state: AppState): Promise<void> {
+    if (!this.db) return;
+    try {
+      const ref = doc(this.db, 'users', uid);
+      // Fittiamo solo i campi che ci interessano sincronizzare. Niente
+      // preferenze UI: restano locali per device.
+      const u = this.auth.user();
+      const userOrNull = u && u !== 'loading' ? u : null;
+      await setDoc(
+        ref,
+        { ...toCloudShape(state, userOrNull), updatedAt: serverTimestamp() },
+        { merge: true },
+      );
+    } catch (e) {
+      console.warn('[firestore] push error:', e);
+    }
+  }
+}
+
+/** Shape di /users/{uid} in Firestore. Solo i campi del game state cross-device. */
+interface CloudUserDoc {
+  nickname: string;
+  avatar: number;
+  email: string;
+  provider: string;
+  joinedAt?: unknown;
+  streak: number;
+  bestStreak: number;
+  played: number;
+  correctAnswers: number;
+  accuracy: number;
+  perScript: Record<string, PerScriptStat>;
+  dailyDone: boolean;
+  dailyDoneStamp: string | null;
+  dailyScore: number;
+  dailyStreak: number;
+  dailyHistory: DailyHistoryEntry[];
+  updatedAt?: unknown;
+}
+
+function toCloudShape(s: AppState, user: User | null): Omit<CloudUserDoc, 'joinedAt' | 'updatedAt'> {
+  const account = s.account;
+  return {
+    nickname: account?.nickname ?? user?.displayName ?? 'lettore',
+    avatar: account?.avatar ?? 0,
+    email: account?.email ?? user?.email ?? '',
+    provider: account?.provider ?? 'password',
+    streak: s.streak,
+    bestStreak: s.bestStreak,
+    played: s.played,
+    correctAnswers: s.correctAnswers,
+    accuracy: s.accuracy,
+    perScript: s.perScript,
+    dailyDone: s.dailyDone,
+    dailyDoneStamp: s.dailyDoneStamp,
+    dailyScore: s.dailyScore,
+    dailyStreak: s.dailyStreak,
+    dailyHistory: s.dailyHistory,
+  };
+}
+
+/**
+ * Merge locale + cloud all'auth iniziale:
+ *  - Contatori cumulativi (played, correctAnswers, bestStreak, dailyStreak):
+ *    max() tra i due lati. Cosi' se hai giocato su due telefoni offline
+ *    accumuli i progressi senza perderli.
+ *  - streak corrente: scegliamo il maggiore (non avendo timestamp affidabili,
+ *    e' una conservativa overestimate, ma non genera bug visibili).
+ *  - accuracy: ricalcoliamo da played + correctAnswers mergiati.
+ *  - perScript: per ogni scrittura, max(tries, correct) tra cloud e locale.
+ *  - dailyDone/dailyDoneStamp/dailyScore: cloud vince se ha uno stamp piu'
+ *    recente (giornaliera e' un evento globale).
+ *  - dailyHistory: unione per `day` (preferisce l'entry con score piu' alto
+ *    se duplicata).
+ *  - nickname/avatar: cloud vince (sono scelte esplicite dell'utente).
+ */
+function mergeStates(local: AppState, cloud: CloudUserDoc): AppState {
+  const merged: AppState = {
+    ...local,
+    // Account: applichiamo cloud su locale (nickname/avatar scelti dall'utente
+    // su un altro device hanno priorita').
+    account: local.account
+      ? {
+          ...local.account,
+          nickname: cloud.nickname || local.account.nickname,
+          avatar: cloud.avatar ?? local.account.avatar,
+        }
+      : local.account,
+    // Contatori cumulativi: max-merge.
+    streak: Math.max(local.streak, cloud.streak ?? 0),
+    bestStreak: Math.max(local.bestStreak, cloud.bestStreak ?? 0),
+    played: Math.max(local.played, cloud.played ?? 0),
+    correctAnswers: Math.max(local.correctAnswers, cloud.correctAnswers ?? 0),
+    perScript: mergePerScript(local.perScript, cloud.perScript ?? {}),
+    // Daily: cloud "vince" se ha lo stesso giorno o uno piu' recente.
+    ...mergeDaily(local, cloud),
+    dailyStreak: Math.max(local.dailyStreak, cloud.dailyStreak ?? 0),
+    dailyHistory: mergeDailyHistory(local.dailyHistory, cloud.dailyHistory ?? []),
+  };
+  // Ricalcola accuracy dai merged.
+  merged.accuracy = merged.played > 0
+    ? Math.round((merged.correctAnswers / merged.played) * 100)
+    : 0;
+  return merged;
+}
+
+function mergePerScript(
+  local: Record<string, PerScriptStat>,
+  cloud: Record<string, PerScriptStat>,
+): Record<string, PerScriptStat> {
+  const out: Record<string, PerScriptStat> = { ...local };
+  for (const [id, c] of Object.entries(cloud)) {
+    const l = out[id];
+    if (!l) {
+      out[id] = c;
+    } else {
+      out[id] = {
+        tries: Math.max(l.tries, c.tries),
+        correct: Math.max(l.correct, c.correct),
+      };
+    }
+  }
+  return out;
+}
+
+function mergeDaily(
+  local: AppState,
+  cloud: CloudUserDoc,
+): Pick<AppState, 'dailyDone' | 'dailyDoneStamp' | 'dailyScore'> {
+  // Se cloud ha uno stamp di "oggi" e local no, prendiamo cloud (l'utente ha
+  // fatto la daily da un altro device). Se entrambi hanno stamps differenti
+  // (oggi vs ieri o altro), prevale il piu' recente.
+  const lStamp = local.dailyDoneStamp;
+  const cStamp = cloud.dailyDoneStamp ?? null;
+  if (!cStamp) return { dailyDone: local.dailyDone, dailyDoneStamp: lStamp, dailyScore: local.dailyScore };
+  if (!lStamp) {
+    return {
+      dailyDone: cloud.dailyDone ?? false,
+      dailyDoneStamp: cStamp,
+      dailyScore: cloud.dailyScore ?? 0,
+    };
+  }
+  // Entrambi presenti: prendiamo quello con stamp lessicograficamente maggiore
+  // (le stamp sono toDateString() o ISO, in genere sortabili come stringa).
+  if (cStamp > lStamp) {
+    return {
+      dailyDone: cloud.dailyDone ?? false,
+      dailyDoneStamp: cStamp,
+      dailyScore: cloud.dailyScore ?? 0,
+    };
+  }
+  if (lStamp === cStamp) {
+    return {
+      dailyDone: local.dailyDone || (cloud.dailyDone ?? false),
+      dailyDoneStamp: lStamp,
+      dailyScore: Math.max(local.dailyScore, cloud.dailyScore ?? 0),
+    };
+  }
+  return { dailyDone: local.dailyDone, dailyDoneStamp: lStamp, dailyScore: local.dailyScore };
+}
+
+function mergeDailyHistory(
+  local: DailyHistoryEntry[],
+  cloud: DailyHistoryEntry[],
+): DailyHistoryEntry[] {
+  const byDay = new Map<string, DailyHistoryEntry>();
+  for (const e of local) byDay.set(e.day, e);
+  for (const e of cloud) {
+    const existing = byDay.get(e.day);
+    if (!existing || e.score > existing.score) {
+      byDay.set(e.day, e);
+    }
+  }
+  return Array.from(byDay.values()).sort((a, b) => a.day.localeCompare(b.day));
+}


### PR DESCRIPTION
Da questa PR i progressi non vivono piu' solo sul dispositivo: quando accedi al tuo profilo, striscia, partite giocate, accuracy, statistiche per scrittura e storico sfide giornaliere vengono salvati su Firestore. Cambi telefono e accedi: ritrovi tutto.

Cosa viene sincronizzato e cosa no

Vanno in cloud i contatori del gioco (streak corrente e migliore, partite, risposte corrette, accuracy, perScript, dailyDone/dailyDoneStamp/dailyScore/dailyStreak, dailyHistory) e i campi anagrafici del profilo (nickname, avatar, email, provider, joinedAt, updatedAt).

Restano locali al singolo dispositivo le preferenze visive (accent, motion, colorblind, sound, haptics, showCodepoint), la selezione delle scritture per la modalita' allenamento, i flag di sessione (hintsLeft, shownFirstWrong) e l'onboarded. Idea: ti ritrovi i progressi sul nuovo telefono, ma puoi avere un tema diverso senza che si propaghi.

Come funziona il merge

Al primo login su un dispositivo (o ad ogni riapertura della app dopo essere loggato), UserDocService legge /users/{uid} da Firestore. Se il documento esiste, fa max-merge: per i contatori cumulativi vince il valore piu' alto tra cloud e locale, cosi' se hai giocato offline su due device entrambi i progressi vengono conservati. La sfida giornaliera segue lo stamp piu' recente. Per nickname e avatar vince il cloud (sono scelte esplicite dell'utente, da rispettare). Se il documento non esiste (primo accesso assoluto), scriviamo lo stato locale come "punto zero".

Dopo il merge iniziale, ad ogni cambio di state (rispondere a una carta, completare la giornaliera, ecc.) parte un push debounced di 1 secondo verso Firestore con setDoc({merge: true}). Niente real-time listening: e' lazy sync, lo stato si rinfresca al prossimo login se da un altro device hai fatto qualcosa di nuovo.

Sotto al cofano

UserDocService usa firebase/firestore/lite invece dell'SDK completo: non abbiamo bisogno di onSnapshot ne' di persistenza offline, e la versione lite tiene il bundle initial sotto i 500kB (siamo a 439kB, prima eravamo a 600kB col Firestore pieno). Il servizio si auto-attiva via effect su auth.user (login/logout) e su state (push debounced). Bootstrap minimale: viene istanziato da App component con un inject "dummy" per farlo partire.

Sicurezza

Le firestore.rules erano gia' deployate dalla PR di setup (#46): /users/{uid} permette lettura pubblica (per profili pubblici futuri), scrittura solo dal proprietario, niente delete. Su create il nickname deve essere stringa 2-24 caratteri.

Cosa NON in questa PR

Niente UI di gestione: il sync e' completamente trasparente, l'utente non vede ne' tasti ne' indicatori. Niente sync in tempo reale tra device aperti simultaneamente (per quello servirebbe onSnapshot e firebase/firestore completo). Niente UI per cambiare nickname o avatar (verra' con la PR del profilo). La collezione /nicknames per l'unicita' non viene popolata: per ora ognuno tiene il suo nickname per uid, niente conflitti.