### PR TITLE
feat(profile): pagina profilo vera + avatar in modale + logout azzera i progressi

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,7 @@ src/
       home/
       login/
       onboarding/
+      profile/
       script-detail/
       selection/
       session-result/
@@ -301,7 +302,7 @@ L'app si appoggia a Firebase Auth + Firestore per login e sincronizzazione del p
 ### Cosa NON e' ancora collegato
 
 - La sincronizzazione di `state` (campi gioco: streak, played, perScript, ecc.) con Firestore al cambio di `auth.user` non e' ancora implementata. Verra' in una PR dedicata. Per ora `state.account` viene popolato dall'Auth ma i progressi restano in `localStorage`.
-- Le route `/profile`, `/leaderboard`, `/u/:nickname` sono ancora `ComingSoon`. Le PR che le accendono usano gia' lo stato Auth (`AuthService.user()`) come fonte di verita'.
+- Le route `/leaderboard`, `/u/:nickname` sono ancora `ComingSoon`. Le PR che le accendono usano gia' lo stato Auth (`AuthService.user()`) come fonte di verita'. `/profile` invece e' diventata reale: hero con avatar editabile (12 glifi predefiniti in `AVATARS`), nickname inline edit (Enter salva, Esc annulla), stats 2x2, lista per-scrittura con barre colorate (verde >=75%, ambra >=40%, rosso <40%), badges teaser, storico daily.
 
 ### Convenzioni
 

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -72,8 +72,13 @@ export const routes: Routes = [
     loadComponent: () => import('./features/login/login').then((m) => m.Login),
   },
 
+  {
+    path: 'profile',
+    canActivate: [onboardedGuard],
+    loadComponent: () => import('./features/profile/profile').then((m) => m.Profile),
+  },
+
   // Aree social ancora stub: profilo pubblico, classifica, sfide tra amici.
-  { path: 'profile',           canActivate: [onboardedGuard], loadComponent: comingSoon },
   { path: 'leaderboard',       canActivate: [onboardedGuard], loadComponent: comingSoon },
   { path: 'u/:nickname',       loadComponent: comingSoon },
 

--- a/src/app/core/state/app-state.service.ts
+++ b/src/app/core/state/app-state.service.ts
@@ -56,7 +56,29 @@ export class AppStateService {
       if (!u) {
         const hadAccount = untracked(() => this._state().account);
         if (hadAccount) {
-          this._state.update((s) => ({ ...s, account: null }));
+          // Logout esplicito: oltre ad azzerare l'account, puliamo i progressi
+          // del gioco da questo dispositivo. Restano salvati sul profilo cloud
+          // (PR #49), quindi al re-login li ritrovi via max-merge.
+          // Preserviamo le preferenze UI (accent, motion, audio, ecc.) e i
+          // flag di setup (onboarded, selected) perche' sono scelte
+          // per-dispositivo, non collegate all'account.
+          this._state.update((s) => ({
+            ...s,
+            account: null,
+            streak: 0,
+            bestStreak: 0,
+            played: 0,
+            correctAnswers: 0,
+            accuracy: 0,
+            perScript: {},
+            dailyDone: false,
+            dailyDoneStamp: null,
+            dailyScore: 0,
+            dailyStreak: 0,
+            dailyHistory: [],
+            hintsLeft: DEFAULT_STATE.hintsLeft,
+            shownFirstWrong: false,
+          }));
         }
         return;
       }

--- a/src/app/features/home/home.css
+++ b/src/app/features/home/home.css
@@ -183,6 +183,17 @@
   font-size: 14px;
 }
 
+/* Quando il trigger contiene l'iniziale (utente loggato) togliamo il bordo
+   quadrato globale di .btn-icon: l'iniziale ha gia' il suo cerchio ambra,
+   un secondo riquadro fa rumore visivo. Quando non si e' loggati, il bordo
+   resta per dare il rettangolo dell'icona omino. */
+.account-trigger:has(.account-initial) {
+  border-color: transparent;
+}
+.account-trigger:has(.account-initial):hover {
+  background: transparent;
+}
+
 /* Popover account: sotto l'icona trigger, allineato a destra. Voci come
    pulsanti pieni, separatore prima del logout, "Esci" colorato danger. */
 .account-menu {

--- a/src/app/features/home/home.html
+++ b/src/app/features/home/home.html
@@ -245,6 +245,9 @@
   @if (signOutDialog()) {
     <app-confirm-dialog
       [title]="i18n.lang() === 'it' ? 'Sei sicuro di uscire?' : 'Are you sure you want to sign out?'"
+      [body]="i18n.lang() === 'it'
+        ? 'I progressi su questo dispositivo verranno azzerati. Restano salvati sul tuo profilo: li ritroverai al prossimo accesso.'
+        : 'Your progress on this device will be cleared. It stays saved on your profile: you\'ll find it again next time you sign in.'"
       [confirmLabel]="i18n.t('logout')"
       [cancelLabel]="i18n.lang() === 'it' ? 'Annulla' : 'Cancel'"
       (confirmed)="confirmSignOut()"

--- a/src/app/features/profile/profile.css
+++ b/src/app/features/profile/profile.css
@@ -1,0 +1,372 @@
+.profile-page {
+  display: flex;
+  flex-direction: column;
+  padding-bottom: 32px;
+}
+
+/* Hero: avatar grande centrato + nickname + email + chip azioni. */
+.profile-hero {
+  text-align: center;
+  padding: 12px 0 8px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+}
+
+.profile-avatar-btn {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  padding: 0;
+  position: relative;
+  display: inline-block;
+  cursor: default;
+}
+.profile-avatar-btn.is-clickable {
+  cursor: pointer;
+}
+.profile-avatar-btn.is-clickable:hover .profile-avatar {
+  filter: brightness(1.05);
+}
+.profile-avatar {
+  display: grid;
+  place-items: center;
+  width: 88px;
+  height: 88px;
+  border-radius: 50%;
+  font-family: var(--font-glyph);
+  font-size: 44px;
+  font-weight: 500;
+  line-height: 1;
+  background: var(--surface-2);
+  color: var(--text);
+  border: 1.5px solid var(--border);
+}
+.profile-avatar.accent {
+  background: var(--accent);
+  color: var(--accent-contrast);
+  border-color: transparent;
+}
+/* Pencil badge in basso a destra dell'avatar, segnale visivo che e' cliccabile. */
+.profile-avatar-pencil {
+  position: absolute;
+  bottom: -2px;
+  right: -2px;
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  background: var(--surface);
+  border: 2px solid var(--bg);
+  display: grid;
+  place-items: center;
+  font-size: 12px;
+  color: var(--text);
+}
+
+/* Nickname: bottone con tipografia h2. Click = passa in edit mode. */
+.profile-nick {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  color: inherit;
+  font: inherit;
+}
+.profile-nick:hover { opacity: 0.85; }
+.profile-nick-text {
+  margin: 0;
+}
+.profile-nick-pencil {
+  font-size: 14px;
+  color: var(--text-mute);
+}
+
+/* Edit mode: input largo come l'h2, bottone OK accanto. */
+.profile-nick-edit {
+  display: flex;
+  align-items: stretch;
+  gap: 8px;
+  max-width: 260px;
+  width: 100%;
+}
+.profile-nick-edit .input-field {
+  flex: 1;
+  width: auto;
+  padding: 8px 12px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  color: var(--text);
+  font-size: 14px;
+  font-family: inherit;
+  outline: none;
+  box-sizing: border-box;
+  transition: border-color var(--hover-dur) ease;
+}
+.profile-nick-edit .input-field:focus { border-color: var(--accent); }
+.profile-nick-save {
+  height: 38px;
+  padding: 0 14px;
+}
+
+.profile-email {
+  font-size: 11px;
+  margin: 0;
+}
+.profile-joined {
+  font-size: 12px;
+  margin: 0;
+}
+
+.profile-anon-hint {
+  max-width: 320px;
+  font-size: 13px;
+  margin: 0;
+  line-height: 1.5;
+}
+.profile-anon-cta {
+  height: 40px;
+  padding: 0 18px;
+  margin-top: 4px;
+}
+
+/* Modale di scelta avatar (backdrop full screen, sheet centrata). La griglia
+   resta uguale a quella che era inline; le voci hanno una pendingAvatar
+   provvisoria che viene confermata solo al tasto Salva. */
+.avatar-backdrop {
+  align-items: center;
+  z-index: 80;
+}
+.avatar-sheet {
+  max-width: 380px;
+  border-radius: 20px;
+  padding: 20px 22px 22px;
+  animation: pop .18s ease;
+}
+.avatar-sheet-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+.avatar-sheet-sub {
+  font-size: 12px;
+  margin: 4px 0 14px;
+}
+.avatar-save {
+  margin-top: 16px;
+}
+
+.profile-avatar-grid {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 8px;
+}
+.profile-avatar-cell {
+  appearance: none;
+  aspect-ratio: 1;
+  border-radius: 12px;
+  background: var(--surface);
+  color: var(--text);
+  border: 1px solid var(--border);
+  font-family: var(--font-glyph);
+  font-size: 22px;
+  font-weight: 500;
+  cursor: pointer;
+  transition:
+    transform var(--hover-dur) ease,
+    background var(--hover-dur) ease,
+    border-color var(--hover-dur) ease;
+}
+.profile-avatar-cell:hover {
+  transform: scale(1.05);
+}
+.profile-avatar-cell.is-active {
+  background: var(--accent);
+  color: var(--accent-contrast);
+  border-color: var(--accent);
+}
+
+/* Chip orizzontali sotto la hero (per ora portano alle pagine ComingSoon). */
+.profile-chips {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+  flex-wrap: wrap;
+  margin-top: 4px;
+}
+
+/* Stats 2x2 (vs la home che e' 1x3): bestStreak + streak + accuracy + played. */
+.profile-stats {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+  margin-top: 22px;
+}
+
+.section-h {
+  margin: 0 0 12px;
+}
+.profile-section-head {
+  margin-bottom: 12px;
+}
+
+/* Lista per-scrittura: griglia [glifo 36 | nome+barra | percentuale]. */
+.profile-scripts {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.profile-script {
+  appearance: none;
+  display: grid;
+  grid-template-columns: 36px 1fr auto;
+  gap: 12px;
+  align-items: center;
+  padding: 10px;
+  border-radius: 12px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  cursor: pointer;
+  font: inherit;
+  color: var(--text);
+  text-align: left;
+  transition:
+    background var(--hover-dur) ease,
+    border-color var(--hover-dur) ease;
+}
+.profile-script:hover {
+  background: var(--surface-2);
+  border-color: var(--border-strong);
+}
+.profile-script-glyph {
+  display: grid;
+  place-items: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 10px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  font-family: var(--font-glyph);
+  font-size: 18px;
+}
+.profile-script-body {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.profile-script-name {
+  font-size: 14px;
+  font-weight: 500;
+}
+.profile-script-bar {
+  display: block;
+  height: 4px;
+  background: var(--surface-2);
+  border-radius: 999px;
+  overflow: hidden;
+}
+.profile-script-bar i {
+  display: block;
+  height: 100%;
+  border-radius: 999px;
+  transition: width 240ms var(--tx-ease);
+}
+/* Soglie colore allineate al mockup: >=75 verde, >=40 ambra, <40 rosso. */
+.profile-script-bar i[data-acc="good"] { background: var(--success); }
+.profile-script-bar i[data-acc="mid"]  { background: var(--warm); }
+.profile-script-bar i[data-acc="bad"]  { background: var(--danger); }
+.profile-script-pct {
+  font-size: 13px;
+  color: var(--text-dim);
+  font-variant-numeric: tabular-nums;
+}
+
+/* Bottone logout nell'app-bar: piu' compatto del default nav-btn. */
+.account-logout {
+  height: 30px;
+  font-size: 12px;
+  padding: 0 12px;
+}
+
+/* Storico daily: una riga di celle scrollabile orizzontalmente, ogni cella e'
+   un quadratino colorato in base al punteggio (gold per 5/5, verde per 4,
+   ambra per 3, dim per < 3). */
+.profile-daily-row {
+  display: flex;
+  gap: 6px;
+  overflow-x: auto;
+  padding: 4px 2px;
+}
+.profile-daily-cell {
+  flex: 0 0 auto;
+  width: 56px;
+  height: 56px;
+  border-radius: 10px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+}
+.profile-daily-cell[data-color="gold"] {
+  background: rgba(251, 191, 36, 0.15);
+  border-color: rgba(251, 191, 36, 0.5);
+}
+.profile-daily-cell[data-color="green"] {
+  background: rgba(52, 211, 153, 0.12);
+  border-color: rgba(52, 211, 153, 0.4);
+}
+.profile-daily-cell[data-color="warm"] {
+  background: rgba(251, 191, 36, 0.08);
+  border-color: rgba(251, 191, 36, 0.3);
+}
+.profile-daily-cell[data-color="dim"] {
+  opacity: 0.6;
+}
+.profile-daily-score {
+  font-weight: 600;
+  font-size: 14px;
+  font-variant-numeric: tabular-nums;
+}
+.profile-daily-day {
+  font-size: 10px;
+  color: var(--text-mute);
+}
+
+/* Il container .badges-teaser e i suoi sotto-elementi (.badges-teaser-text,
+   .badges-teaser-title, .badges-teaser-sub) sono definiti in styles.css
+   globale e in home.css; qui sotto solo l'override del text-align del button
+   (i button hanno text-align: center di default). */
+.badges-teaser-text {
+  text-align: left;
+}
+.badges-teaser-title {
+  font-weight: 500;
+  font-size: 15px;
+  line-height: 1.2;
+}
+.badges-teaser-title .sep {
+  color: var(--text-mute);
+  margin: 0 2px;
+}
+.badges-teaser-title .v {
+  color: var(--accent);
+  font-weight: 600;
+}
+.badges-teaser-title .l {
+  color: var(--text-mute);
+}
+.badges-teaser-sub {
+  font-size: 12px;
+  margin-top: 4px;
+  line-height: 1.4;
+}

--- a/src/app/features/profile/profile.html
+++ b/src/app/features/profile/profile.html
@@ -1,0 +1,246 @@
+<div class="app-shell">
+  <app-bar [canBack]="true"
+           [title]="i18n.lang() === 'it' ? 'Profilo' : 'Profile'"
+           (back)="goBack()"
+           (goHome)="goHome()">
+    @if (account()) {
+      <button class="nav-btn account-logout" type="button" (click)="askSignOut()">
+        {{ i18n.t('logout') }}
+      </button>
+    }
+  </app-bar>
+
+  <div class="page profile-page">
+    <!-- Hero: avatar grande + nickname + email -->
+    <div class="profile-hero">
+      <button
+        type="button"
+        class="profile-avatar-btn"
+        [class.is-clickable]="account()"
+        (click)="account() ? openAvatarPicker() : goLogin()"
+        [attr.aria-label]="account()
+          ? (i18n.lang() === 'it' ? 'Cambia avatar' : 'Change avatar')
+          : i18n.t('login')"
+      >
+        <span class="profile-avatar accent">{{ currentAvatar().glyph }}</span>
+        @if (account()) {
+          <span class="profile-avatar-pencil" aria-hidden="true">✎</span>
+        }
+      </button>
+
+      @if (account(); as a) {
+        @if (editingNick()) {
+          <div class="profile-nick-edit">
+            <input
+              class="input-field"
+              type="text"
+              autofocus
+              [ngModel]="nickDraft()"
+              (ngModelChange)="nickDraft.set($event)"
+              (keydown.enter)="saveNick()"
+              (keydown.escape)="cancelEditNick()"
+              maxlength="24"
+              minlength="2"
+            />
+            <button class="btn btn-primary profile-nick-save" type="button" (click)="saveNick()">OK</button>
+          </div>
+        } @else {
+          <button
+            type="button"
+            class="profile-nick"
+            (click)="startEditNick()"
+            [attr.aria-label]="i18n.lang() === 'it' ? 'Modifica nickname' : 'Edit nickname'"
+          >
+            <span class="h2 profile-nick-text">{{ a.nickname }}</span>
+            <span class="profile-nick-pencil" aria-hidden="true">✎</span>
+          </button>
+        }
+        <p class="muted mono profile-email">{{ a.email }}</p>
+        @if (joinedLabel(); as j) {
+          <p class="muted profile-joined">
+            {{ i18n.lang() === 'it' ? 'Iscritto da' : 'Member since' }} {{ j }}
+          </p>
+        }
+      } @else {
+        <h2 class="h2">{{ i18n.lang() === 'it' ? 'Anonimo' : 'Guest' }}</h2>
+        <p class="muted profile-anon-hint">
+          {{ i18n.lang() === 'it'
+            ? 'Crea un profilo per salvare i progressi su tutti i dispositivi.'
+            : 'Sign in to sync your progress across devices.' }}
+        </p>
+        <button class="btn btn-primary profile-anon-cta" type="button" (click)="goLogin()">
+          {{ i18n.t('login') }}
+        </button>
+      }
+    </div>
+
+    @if (account()) {
+      <!-- Azione rapida: porta alla classifica (per ora ComingSoon). La chip
+           "Profilo pubblico" l'abbiamo tolta da qui: visitare la pagina del
+           proprio profilo pubblico dal proprio profilo era un giro a vuoto.
+           La pagina /u/:nickname esiste lo stesso per quando ti capita il link
+           del profilo di qualcun altro (dalla classifica futura). -->
+      <div class="profile-chips">
+        <button class="nav-btn" type="button" (click)="goLeaderboard()">
+          {{ i18n.t('leaderboard') }}
+        </button>
+      </div>
+    }
+
+    <!-- Stats 2x2 -->
+    <div class="profile-stats">
+      <div class="stat">
+        <span class="v">{{ state().streak }}</span>
+        <span class="l">{{ i18n.t('streak') }}</span>
+      </div>
+      <div class="stat">
+        <span class="v">{{ state().bestStreak }}</span>
+        <span class="l">{{ i18n.t('bestStreak') }}</span>
+      </div>
+      <div class="stat">
+        <span class="v">{{ state().accuracy }}%</span>
+        <span class="l">{{ i18n.t('accuracy') }}</span>
+      </div>
+      <div class="stat">
+        <span class="v">{{ state().played }}</span>
+        <span class="l">{{ i18n.t('played') }}</span>
+      </div>
+    </div>
+
+    <div class="divider"></div>
+
+    <h3 class="h3 section-h">
+      {{ i18n.lang() === 'it' ? 'Per scrittura' : 'By script' }}
+    </h3>
+    @if (scriptStats().length === 0) {
+      <p class="muted">
+        {{ i18n.lang() === 'it'
+          ? 'Gioca qualche partita per vedere i progressi.'
+          : 'Play a few rounds to see your progress here.' }}
+      </p>
+    } @else {
+      <div class="profile-scripts">
+        @for (e of scriptStats(); track e.id) {
+          <button class="profile-script" type="button" (click)="openScript(e.id)">
+            <span class="profile-script-glyph">{{ e.script?.sample }}</span>
+            <div class="profile-script-body">
+              <span class="profile-script-name">
+                {{ i18n.lang() === 'it' ? e.script?.nameIt : e.script?.nameEn }}
+              </span>
+              <span class="profile-script-bar">
+                <i [style.width.%]="e.acc" [attr.data-acc]="accLevel(e.acc)"></i>
+              </span>
+            </div>
+            <span class="profile-script-pct mono">{{ e.acc }}%</span>
+          </button>
+        }
+      </div>
+    }
+
+    <div class="divider"></div>
+
+    <div class="section-head profile-section-head">
+      <h3 class="h3">{{ i18n.t('badges') }}</h3>
+      <button class="nav-btn small" type="button" (click)="goBadges()">
+        <span>{{ i18n.t('seeAll') }}</span>
+        <app-icon name="arrow-right" />
+      </button>
+    </div>
+    <button class="badges-teaser" type="button" (click)="goBadges()">
+      <div class="badges-teaser-text">
+        <div class="badges-teaser-title">
+          {{ i18n.t('badges') }}
+          <span class="sep" aria-hidden="true">·</span>
+          <span class="v">{{ badgeStats().unlocked }}</span>
+          <span class="l">/ {{ badgeStats().total }}</span>
+        </div>
+        <div class="badges-teaser-sub muted">
+          @if (badgeStats().unlocked === 0) {
+            {{ i18n.lang() === 'it'
+              ? 'Comincia a giocare per sbloccare il primo.'
+              : 'Start playing to unlock your first one.' }}
+          } @else if (!badgeStats().nextLocked) {
+            {{ i18n.lang() === 'it' ? 'Li hai sbloccati tutti.' : 'You unlocked them all.' }}
+          } @else if (i18n.lang() === 'it') {
+            {{ badgeStats().unlocked }} sbloccati. Prossimo: {{ nextLockedTitle() }}
+          } @else {
+            {{ badgeStats().unlocked }} unlocked. Next: {{ nextLockedTitle() }}
+          }
+        </div>
+      </div>
+      <div class="icons">
+        @for (b of badgeStats().preview; track b.id) {
+          <span [attr.data-on]="b.unlocked ? '1' : '0'" [attr.data-t]="b.tier">{{ b.icon }}</span>
+        }
+      </div>
+    </button>
+
+    <div class="divider"></div>
+
+    <h3 class="h3 section-h">
+      {{ i18n.lang() === 'it' ? 'Sfida giornaliera' : 'Daily challenge' }}
+    </h3>
+    @if (dailyHistory().length === 0) {
+      <p class="muted">
+        {{ i18n.lang() === 'it'
+          ? 'Ancora nessuna sfida giornaliera completata.'
+          : 'No daily challenges completed yet.' }}
+      </p>
+    } @else {
+      <div class="profile-daily-row">
+        @for (d of dailyHistory(); track d.day) {
+          <div class="profile-daily-cell" [attr.data-color]="daySquareColor(d.score)">
+            <span class="profile-daily-score">{{ d.score }}/5</span>
+            <span class="profile-daily-day mono">{{ formatDay(d.day) }}</span>
+          </div>
+        }
+      </div>
+    }
+  </div>
+
+  @if (pickingAvatar()) {
+    <div class="sheet-backdrop avatar-backdrop" (click)="closeAvatarPicker()">
+      <div class="sheet avatar-sheet" (click)="$event.stopPropagation()">
+        <div class="avatar-sheet-head">
+          <h2 class="h2">{{ i18n.lang() === 'it' ? 'Scegli un glifo' : 'Pick a glyph' }}</h2>
+          <button class="btn-icon" type="button" (click)="closeAvatarPicker()"
+                  [attr.aria-label]="i18n.lang() === 'it' ? 'Chiudi' : 'Close'">
+            <app-icon name="close" />
+          </button>
+        </div>
+        <p class="muted avatar-sheet-sub">
+          {{ i18n.lang() === 'it'
+            ? 'Tocca per selezionare, poi premi Salva.'
+            : 'Tap to select, then press Save.' }}
+        </p>
+        <div class="profile-avatar-grid">
+          @for (a of avatars; track a.id) {
+            <button class="profile-avatar-cell"
+                    [class.is-active]="pendingAvatar() === a.id"
+                    type="button"
+                    (click)="pickAvatar(a.id)"
+                    [attr.aria-label]="a.label">
+              {{ a.glyph }}
+            </button>
+          }
+        </div>
+        <button class="btn btn-primary btn-block avatar-save" type="button" (click)="saveAvatar()">
+          {{ i18n.lang() === 'it' ? 'Salva' : 'Save' }}
+        </button>
+      </div>
+    </div>
+  }
+
+  @if (signOutDialog()) {
+    <app-confirm-dialog
+      [title]="i18n.lang() === 'it' ? 'Sei sicuro di uscire?' : 'Are you sure you want to sign out?'"
+      [body]="i18n.lang() === 'it'
+        ? 'I progressi su questo dispositivo verranno azzerati. Restano salvati sul tuo profilo: li ritroverai al prossimo accesso.'
+        : 'Your progress on this device will be cleared. It stays saved on your profile: you\'ll find it again next time you sign in.'"
+      [confirmLabel]="i18n.t('logout')"
+      [cancelLabel]="i18n.lang() === 'it' ? 'Annulla' : 'Cancel'"
+      (confirmed)="confirmSignOut()"
+      (cancel)="cancelSignOut()"
+    />
+  }
+</div>

--- a/src/app/features/profile/profile.ts
+++ b/src/app/features/profile/profile.ts
@@ -1,0 +1,218 @@
+import { ChangeDetectionStrategy, Component, HostListener, computed, inject, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { Location } from '@angular/common';
+import { Router } from '@angular/router';
+import { I18nService } from '../../core/i18n/i18n.service';
+import { AppStateService } from '../../core/state/app-state.service';
+import { AuthService } from '../../core/firebase/auth.service';
+import { AVATARS, avatarById } from '../../core/data/avatars';
+import { scriptById } from '../../core/data/scripts';
+import { computeBadges } from '../../core/data/badges';
+import { AppBar } from '../../shared/app-bar';
+import { ConfirmDialog } from '../../shared/confirm-dialog';
+import { Icon } from '../../shared/icon';
+
+@Component({
+  selector: 'app-profile',
+  imports: [AppBar, ConfirmDialog, Icon, FormsModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './profile.html',
+  styleUrl: './profile.css',
+})
+export class Profile {
+  private readonly router = inject(Router);
+  private readonly location = inject(Location);
+  protected readonly i18n = inject(I18nService);
+  protected readonly appState = inject(AppStateService);
+  private readonly authSvc = inject(AuthService);
+
+  protected readonly state = this.appState.state;
+  protected readonly avatars = AVATARS;
+
+  protected readonly account = computed(() => this.state().account);
+  protected readonly currentAvatar = computed(() => avatarById(this.account()?.avatar));
+
+  /** Editor inline del nickname: input + tasto OK. */
+  protected readonly editingNick = signal(false);
+  protected readonly nickDraft = signal('');
+
+  /** Modale di scelta avatar. `pendingAvatar` tiene la selezione provvisoria
+   *  mentre la modale e' aperta: l'utente puo' cliccare avatar diversi per
+   *  vedere come si vedono, poi conferma con Salva o annulla con X. */
+  protected readonly pickingAvatar = signal(false);
+  protected readonly pendingAvatar = signal<number | null>(null);
+
+  /** Dialog di conferma logout. */
+  protected readonly signOutDialog = signal(false);
+
+  /** Per-scrittura, ordinate dalla migliore alla peggiore accuratezza. */
+  protected readonly scriptStats = computed(() => {
+    const entries = Object.entries(this.state().perScript ?? {})
+      .map(([id, v]) => ({
+        id,
+        tries: v.tries,
+        correct: v.correct,
+        acc: v.tries > 0 ? Math.round((100 * v.correct) / v.tries) : 0,
+        script: scriptById(id),
+      }))
+      .filter((e) => e.tries >= 1 && e.script);
+    return entries.sort((a, b) => b.acc - a.acc);
+  });
+
+  /** Conteggio badge + preview per la teaser (stesso pattern della home). */
+  protected readonly badgeStats = computed(() => {
+    const list = computeBadges(this.state());
+    const unlocked = list.filter((b) => b.unlocked);
+    const locked = list
+      .filter((b) => !b.unlocked)
+      .sort((a, b) => b.progress - a.progress);
+    const preview = [
+      ...unlocked.slice(0, 2),
+      ...locked.slice(0, 4 - Math.min(unlocked.length, 2)),
+    ].slice(0, 4);
+    const nextLocked = locked[0] ?? null;
+    return { total: list.length, unlocked: unlocked.length, preview, nextLocked };
+  });
+
+  protected nextLockedTitle(): string {
+    const next = this.badgeStats().nextLocked;
+    if (!next) return '';
+    return this.i18n.lang() === 'en' ? next.titleEn : next.titleIt;
+  }
+
+  /** Storico daily (max 14 piu' recenti, in ordine cronologico inverso). */
+  protected readonly dailyHistory = computed(() => {
+    const list = this.state().dailyHistory ?? [];
+    return [...list].sort((a, b) => b.day.localeCompare(a.day)).slice(0, 14);
+  });
+
+  /** "Iscritto da MMMM YYYY" (anche per anon viene "" se manca lo stamp). */
+  protected readonly joinedLabel = computed(() => {
+    const stamp = this.account()?.joinedStamp;
+    if (!stamp) return '';
+    const d = new Date(stamp);
+    if (Number.isNaN(d.getTime())) return '';
+    const locale = this.i18n.lang() === 'it' ? 'it-IT' : 'en-GB';
+    return d.toLocaleDateString(locale, { month: 'long', year: 'numeric' });
+  });
+
+  protected startEditNick(): void {
+    const a = this.account();
+    if (!a) return;
+    this.nickDraft.set(a.nickname);
+    this.editingNick.set(true);
+  }
+
+  protected saveNick(): void {
+    const v = this.nickDraft().trim();
+    if (v.length < 2 || v.length > 24) return;
+    this.appState.updateAccount({ nickname: v });
+    this.editingNick.set(false);
+  }
+
+  protected cancelEditNick(): void {
+    this.editingNick.set(false);
+  }
+
+  protected openAvatarPicker(): void {
+    if (!this.account()) return;
+    this.pendingAvatar.set(this.account()?.avatar ?? 0);
+    this.pickingAvatar.set(true);
+  }
+
+  protected closeAvatarPicker(): void {
+    this.pickingAvatar.set(false);
+    this.pendingAvatar.set(null);
+  }
+
+  /** Seleziona un avatar nella modale (solo provvisorio: non scrive ancora). */
+  protected pickAvatar(id: number): void {
+    this.pendingAvatar.set(id);
+  }
+
+  /** Conferma la scelta: scrive in state.account, l'auto-sync (UserDocService
+   *  in PR #49) propaga a Firestore in automatico. */
+  protected saveAvatar(): void {
+    const id = this.pendingAvatar();
+    if (id == null) return;
+    this.appState.updateAccount({ avatar: id });
+    this.closeAvatarPicker();
+  }
+
+  protected accLevel(pct: number): 'good' | 'mid' | 'bad' {
+    if (pct >= 75) return 'good';
+    if (pct >= 40) return 'mid';
+    return 'bad';
+  }
+
+  /** Mappa il punteggio della daily (0-5) a un colore semantico per la card. */
+  protected daySquareColor(score: number): 'gold' | 'green' | 'warm' | 'dim' {
+    if (score >= 5) return 'gold';
+    if (score >= 4) return 'green';
+    if (score >= 3) return 'warm';
+    return 'dim';
+  }
+
+  /** Formato compatto giorno: "12 mag". */
+  protected formatDay(day: string): string {
+    const d = new Date(day);
+    if (Number.isNaN(d.getTime())) return day;
+    return d.toLocaleDateString(this.i18n.lang() === 'it' ? 'it-IT' : 'en-GB', {
+      day: 'numeric',
+      month: 'short',
+    });
+  }
+
+  protected openScript(id: string): void {
+    this.router.navigate(['/script', id]);
+  }
+
+  protected goBadges(): void {
+    this.router.navigate(['/badges']);
+  }
+
+  protected goLogin(): void {
+    this.router.navigate(['/login']);
+  }
+
+  protected goLeaderboard(): void {
+    this.router.navigate(['/leaderboard']);
+  }
+
+  protected goPublicProfile(): void {
+    const nick = this.account()?.nickname;
+    if (!nick) return;
+    this.router.navigate(['/u', nick]);
+  }
+
+  protected askSignOut(): void {
+    this.signOutDialog.set(true);
+  }
+  protected cancelSignOut(): void {
+    this.signOutDialog.set(false);
+  }
+  protected async confirmSignOut(): Promise<void> {
+    this.signOutDialog.set(false);
+    try {
+      await this.authSvc.signOut();
+    } catch {
+      // sessione locale viene rimossa comunque
+    }
+    this.router.navigate(['/home']);
+  }
+
+  protected goBack(): void {
+    this.location.back();
+  }
+
+  protected goHome(): void {
+    this.router.navigate(['/home']);
+  }
+
+  @HostListener('window:keydown.escape')
+  protected onEscape(): void {
+    if (this.editingNick()) this.cancelEditNick();
+    else if (this.pickingAvatar()) this.closeAvatarPicker();
+    else if (this.signOutDialog()) this.cancelSignOut();
+  }
+}


### PR DESCRIPTION
Da questa PR la route /profile non e' piu' un placeholder ComingSoon ma una vera pagina profilo, e il logout pulisce i progressi sul dispositivo lasciandoli safe sul cloud.

Pagina profilo

Si arriva dal menu account in alto a destra della home, voce Profilo. Hero centrato: avatar 88px col tuo glifo su sfondo ambra, con una matita in basso a destra che invita al click; sotto il nickname (cliccabile per editarlo inline con Enter per salvare, Esc per annullare), email mono e linea "Iscritto da MMMM YYYY".

Sotto la hero, una chip "Classifica" (per ora porta al ComingSoon, ma il tasto resta perche' aggiungeremo la leaderboard in una PR successiva). La chip "Profilo pubblico" del mockup l'ho tolta: visitare il proprio profilo pubblico dal proprio profilo era un giro a vuoto. La pagina /u/:nickname resta da fare quando avra' senso (cioe' quando ci sara' una classifica da cui clicca per vedere il profilo di altri).

Sezione stats 2x2: streak, migliore, accuracy, partite. Lista "Per scrittura" con glifo a sinistra, nome + barra colorata in base all'accuratezza (verde >=75%, ambra >=40%, rossa <40%), percentuale a destra. Click su una riga apre la scheda della scrittura. Sotto, badges teaser (stessa della home) con link "Tutti" verso /traguardi. In fondo, storico delle ultime 14 sfide giornaliere: ogni cella e' colorata in base al punteggio (oro per 5/5, verde per 4/5, ambra per 3/5, dim sotto).

Logout dal tasto Esci in alto a destra dell'app-bar, con la solita modale di conferma.

Avatar in modale

Click sull'avatar (o sulla matita): si apre una modale centrata con titolo "Scegli un glifo", X in alto a destra, sottotitolo "Tocca per selezionare, poi premi Salva", griglia 6 colonne x 2 righe con i 12 avatar predefiniti, bottone Salva a tutta larghezza in fondo. Lo stato `pendingAvatar` separa la selezione provvisoria dal salvataggio effettivo: puoi cliccare diverse opzioni per vedere quale ti piace senza committare. X / backdrop / Esc chiudono senza salvare.

L'avatar selezionato finisce in state.account.avatar (numero 0-11), e dopo merge di PR #49 verra' sincronizzato in /users/{uid}.avatar su Firestore in automatico.

Logout azzera i progressi

Comportamento nuovo: al logout, oltre a svuotare state.account (gia' come prima), azzeriamo anche i contatori di gioco (streak, played, perScript, dailyHistory, ecc.) e i flag di sessione (hintsLeft, shownFirstWrong). Restano le preferenze UI (accent, motion, colorblind, sound, haptics, showCodepoint) e i flag di setup (onboarded, selected) perche' sono scelte per-dispositivo, non collegate all'account.

Motivazione: pattern dominante per le app di apprendimento (Duolingo, Memrise) e' clean al logout. Evita la situazione "se Alice esce, Bob vede i progressi di Alice". Dopo PR #49 i dati sono comunque in cloud quindi nessuna perdita: al re-login il max-merge ripopola tutto.

Modale di conferma aggiornata in TUTTE e due i posti (menu home + tasto in /profilo): "Sei sicuro di uscire? I progressi su questo dispositivo verranno azzerati. Restano salvati sul tuo profilo: li ritroverai al prossimo accesso."

Piccolo fix grafico

L'icona profilo nella home, quando sei loggato, non ha piu' il bordo squadrato bianco attorno al cerchio ambra con l'iniziale: era un "doppio riquadro" che disturbava. Quando non sei loggato (icona omino generica) il bordo resta come prima.

Cosa NON in questa PR

Nickname unico: in attesa che PR #49 (firestore sync) sia su main, perche' la transazione di claim/release vivra' come estensione di UserDocService. Verra' in PR successiva insieme alla pagina /u/:nickname vera. Per ora due utenti possono avere lo stesso nickname, ma e' invisibile finche' non c'e' una pagina pubblica che lo mostra.