### PR TITLE
feat(profile): nickname unico via Firestore + pagina profilo pubblico

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,7 @@ src/
       login/
       onboarding/
       profile/
+      public-profile/
       script-detail/
       selection/
       session-result/
@@ -296,7 +297,8 @@ L'app si appoggia a Firebase Auth + Firestore per login e sincronizzazione del p
 - `src/app/core/firebase/firebase.config.ts`: oggetto config pubblico (committato come placeholder, da riempire).
 - `src/app/core/firebase/firebase.ts`: `ensureFirebaseApp()` inizializza l'app idempotente; ritorna `null` se config = PLACEHOLDER (modalita' offline-only).
 - `src/app/core/firebase/auth.service.ts`: `AuthService` con signal `user` (`User | null | 'loading'`), `enabled` (boolean), metodi `signInEmail/signUpEmail/signInGoogle/signOut`. Quando `enabled === false` i metodi rigettano con `AuthDisabledError`.
-- `src/app/core/firebase/user-doc.service.ts`: `UserDocService` che sincronizza lo stato di gioco con `/users/{uid}` su Firestore quando l'utente e' loggato. Bootstrap-attivato (inject dummy in `App`). All'auth.user che diventa autenticato fa max-merge tra locale e cloud; ad ogni cambio di state mentre loggato, push debounced di 1s. Usa `firebase/firestore/lite` (no real-time, no offline persistence) per tenere il bundle sotto i 500kB.
+- `src/app/core/firebase/user-doc.service.ts`: `UserDocService` che sincronizza lo stato di gioco con `/users/{uid}` su Firestore quando l'utente e' loggato. Bootstrap-attivato (inject dummy in `App`). All'auth.user che diventa autenticato fa max-merge tra locale e cloud; al primo signup chiama `NicknameService.findAvailable` per claimare un nickname unico. Ad ogni cambio di state mentre loggato, push debounced di 1s. Usa `firebase/firestore/lite` (no real-time, no offline persistence) per tenere il bundle sotto i 500kB.
+- `src/app/core/firebase/nickname.service.ts`: `NicknameService` gestisce la collezione `/nicknames/{nick_lowercased}` per garantire l'unicita' del nickname. Metodi: `claim(nick, uid)` atomica via runTransaction, `change(oldNick, newNick, uid)` swap atomico (release vecchio + claim nuovo + update `/users/{uid}.nickname` in una sola transazione), `findAvailable(seed, uid)` cerca varianti seed/seed2/seed3/.../seed-rnd, `getUserByNickname(nick)` per il profilo pubblico.
 - `AppStateService` si abbona al signal `auth.user` via `effect`: a ogni cambio di stato Auth, riflette in `state.account` (uid, email, nickname seedato da `displayName` per Google, avatar 0 di default).
 - `firestore.rules`, `firebase.json`, `.firebaserc` alla root: config per `firebase deploy`. Schema corrente: `/users/{uid}` (stato gioco + anagrafica) e `/nicknames/{nick}` (indice unicita', non ancora popolato).
 
@@ -318,8 +320,9 @@ Le scritture successive durante la sessione fanno **full overwrite** del documen
 
 ### Cosa NON e' ancora collegato
 
-- Le route `/leaderboard`, `/u/:nickname` sono ancora `ComingSoon`. Le PR che le accendono usano gia' lo stato Auth (`AuthService.user()`) come fonte di verita' e i progressi cloud da `/users/{uid}`. `/profile` invece e' diventata reale: hero con avatar editabile in modale (12 glifi predefiniti in `AVATARS`), nickname inline edit (Enter salva, Esc annulla), stats 2x2, lista per-scrittura con barre colorate (verde >=75%, ambra >=40%, rosso <40%), badges teaser, storico daily.
-- Unicita' del nickname via `/nicknames/{nick}` non ancora applicata: il nickname si edita ma due utenti possono avere lo stesso. Verra' attivata con la pagina /u/:nickname pubblica vera.
+- La route `/leaderboard` e' ancora `ComingSoon`. La PR che la accendera' usera' gia' lo stato Auth (`AuthService.user()`) come fonte di verita' e i progressi cloud da `/users/{uid}`.
+- `/profile` reale: hero con avatar editabile in modale (12 glifi predefiniti in `AVATARS`), nickname inline edit (Enter salva, Esc annulla, errore "gia' preso" via transazione `NicknameService.change`), stats 2x2, lista per-scrittura con barre colorate (verde >=75%, ambra >=40%, rosso <40%), badges teaser, storico daily.
+- `/u/:nickname` profilo pubblico reale: faux URL bar in cima, avatar 96px, "Membro da MMMM YYYY", stats 2x2 (best, accuracy, played, dailyStreak), griglia 4-col dei badge sbloccati. CTA in fondo cambia in base a "tu / altri": se sei tu mostra "Condividi profilo", altrimenti "Vuoi battere X? Gioca anche tu". Read pubblica via `NicknameService.getUserByNickname` (no auth richiesta, le regole Firestore permettono read pubblica su `/users` e `/nicknames`).
 
 ### Convenzioni
 

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -78,9 +78,16 @@ export const routes: Routes = [
     loadComponent: () => import('./features/profile/profile').then((m) => m.Profile),
   },
 
-  // Aree social ancora stub: profilo pubblico, classifica, sfide tra amici.
+  // Aree social ancora stub: classifica, sfide tra amici.
   { path: 'leaderboard',       canActivate: [onboardedGuard], loadComponent: comingSoon },
-  { path: 'u/:nickname',       loadComponent: comingSoon },
+
+  // Profilo pubblico di un utente qualunque. NO onboardedGuard: deve essere
+  // raggiungibile anche da link condiviso fuori dall'app prima di essere
+  // onboarded (nel caso l'utente non abbia ancora visto l'onboarding).
+  {
+    path: 'u/:nickname',
+    loadComponent: () => import('./features/public-profile/public-profile').then((m) => m.PublicProfile),
+  },
 
   { path: '**', redirectTo: 'home' },
 ];

--- a/src/app/core/firebase/nickname.service.ts
+++ b/src/app/core/firebase/nickname.service.ts
@@ -1,0 +1,166 @@
+import { Injectable } from '@angular/core';
+import {
+  Firestore,
+  doc,
+  getDoc,
+  getFirestore,
+  runTransaction,
+} from 'firebase/firestore/lite';
+import { ensureFirebaseApp } from './firebase';
+
+/**
+ * Gestisce l'unicita' del nickname tramite la collezione `/nicknames/{nick}`,
+ * dove `nick` e' la versione **lowercased** del nickname (cosi' "Alessio" e
+ * "alessio" mappano sulla stessa entry e non si possono "rubare" l'un l'altro).
+ * Il documento contiene solo `{ uid }`: chi possiede quella entry e' il
+ * proprietario del nickname.
+ *
+ * Le regole Firestore garantiscono:
+ *  - chiunque puo' leggere (per il profilo pubblico)
+ *  - solo l'utente loggato puo' creare un'entry con il proprio uid
+ *  - update non e' mai consentito (devi cancellare e ricreare)
+ *  - delete consentito solo al proprietario
+ *
+ * Le transazioni di `change` garantiscono atomicita' tra release del vecchio
+ * nickname, claim del nuovo e aggiornamento di `/users/{uid}.nickname`.
+ */
+@Injectable({ providedIn: 'root' })
+export class NicknameService {
+  private readonly db: Firestore | null;
+
+  constructor() {
+    const app = ensureFirebaseApp();
+    this.db = app ? getFirestore(app) : null;
+  }
+
+  /** True se il backend e' disponibile (config Firebase reale, non placeholder). */
+  get enabled(): boolean {
+    return this.db !== null;
+  }
+
+  /** Normalizza un nickname per usarlo come chiave (lowercased, trim). */
+  private key(nick: string): string {
+    return nick.trim().toLowerCase();
+  }
+
+  /**
+   * Tenta di claimare atomicamente un nickname per l'uid dato.
+   *  - 'claimed': era libero, ora e' tuo
+   *  - 'taken-by-me': era gia' tuo (idempotente)
+   *  - 'taken-by-other': non disponibile
+   */
+  async claim(nick: string, uid: string): Promise<'claimed' | 'taken-by-me' | 'taken-by-other'> {
+    if (!this.db) throw new Error('Firebase not configured');
+    const ref = doc(this.db, 'nicknames', this.key(nick));
+    return await runTransaction(this.db, async (tx) => {
+      const snap = await tx.get(ref);
+      if (snap.exists()) {
+        const data = snap.data();
+        if (data?.['uid'] === uid) return 'taken-by-me';
+        return 'taken-by-other';
+      }
+      tx.set(ref, { uid });
+      return 'claimed';
+    });
+  }
+
+  /**
+   * Cambia il nickname da `oldNick` a `newNick` in modo atomico:
+   *  1. Verifica che `newNick` sia libero o gia' tuo
+   *  2. Crea l'entry del nuovo se non c'era
+   *  3. Cancella l'entry del vecchio (se esiste ed e' tua)
+   *  4. Aggiorna `/users/{uid}.nickname` al nuovo valore
+   *
+   * Tutte le operazioni avvengono in una sola transazione: se uno step
+   * fallisce, niente viene committato.
+   */
+  async change(
+    oldNick: string | null,
+    newNick: string,
+    uid: string,
+  ): Promise<'ok' | 'taken'> {
+    if (!this.db) throw new Error('Firebase not configured');
+    const oldKey = oldNick ? this.key(oldNick) : null;
+    const newKey = this.key(newNick);
+    if (oldKey === newKey) {
+      // Stesso nickname (o solo cambio di maiuscole): aggiorna /users e basta.
+      const userRef = doc(this.db, 'users', uid);
+      await runTransaction(this.db, async (tx) => {
+        tx.update(userRef, { nickname: newNick });
+      });
+      return 'ok';
+    }
+    return await runTransaction(this.db, async (tx) => {
+      // ── Letture in cima (vincolo Firestore transactions). ──
+      const newRef = doc(this.db!, 'nicknames', newKey);
+      const newSnap = await tx.get(newRef);
+      const oldRef = oldKey ? doc(this.db!, 'nicknames', oldKey) : null;
+      const oldSnap = oldRef ? await tx.get(oldRef) : null;
+      const userRef = doc(this.db!, 'users', uid);
+
+      // ── Validazione. ──
+      if (newSnap.exists() && newSnap.data()?.['uid'] !== uid) {
+        return 'taken';
+      }
+
+      // ── Scritture. ──
+      if (!newSnap.exists()) {
+        tx.set(newRef, { uid });
+      }
+      if (oldRef && oldSnap?.exists() && oldSnap.data()?.['uid'] === uid) {
+        tx.delete(oldRef);
+      }
+      tx.update(userRef, { nickname: newNick });
+      return 'ok';
+    });
+  }
+
+  /**
+   * Trova un nickname disponibile partendo da `seed`. Prova seed, seed2,
+   * ..., seed5, poi `seed-<rnd4>`. Usato in fase di primo signup per evitare
+   * collisioni con altri utenti che hanno la stessa email-prefix o stesso
+   * displayName Google.
+   *
+   * Garantisce che al ritorno il nickname risulti claimed per `uid`.
+   */
+  async findAvailable(seed: string, uid: string): Promise<string> {
+    const base = seed.trim() || 'lettore';
+    const candidates = [base, `${base}2`, `${base}3`, `${base}4`, `${base}5`];
+    for (const c of candidates) {
+      try {
+        const r = await this.claim(c, uid);
+        if (r === 'claimed' || r === 'taken-by-me') return c;
+      } catch {
+        // Transient: continua al prossimo candidato
+      }
+    }
+    // Fallback: aggiungi 4 caratteri pseudo-random
+    const rnd = Math.random().toString(36).slice(2, 6);
+    const last = `${base}-${rnd}`;
+    try {
+      const r = await this.claim(last, uid);
+      if (r === 'claimed' || r === 'taken-by-me') return last;
+    } catch {
+      // ignore
+    }
+    return last;
+  }
+
+  /**
+   * Legge il documento utente partendo dal nickname (per il profilo pubblico).
+   * Due step: /nicknames/{nick} -> uid -> /users/{uid}. Restituisce null se
+   * il nickname non esiste o se il doc utente non si trova.
+   */
+  async getUserByNickname(nick: string): Promise<({ uid: string } & Record<string, unknown>) | null> {
+    if (!this.db) return null;
+    const nickRef = doc(this.db, 'nicknames', this.key(nick));
+    const nickSnap = await getDoc(nickRef);
+    if (!nickSnap.exists()) return null;
+    const uid = nickSnap.data()?.['uid'];
+    if (typeof uid !== 'string') return null;
+    const userRef = doc(this.db, 'users', uid);
+    const userSnap = await getDoc(userRef);
+    if (!userSnap.exists()) return null;
+    return { uid, ...userSnap.data() };
+  }
+}

--- a/src/app/core/firebase/user-doc.service.ts
+++ b/src/app/core/firebase/user-doc.service.ts
@@ -14,6 +14,7 @@ import {
 } from 'firebase/firestore/lite';
 import { ensureFirebaseApp } from './firebase';
 import { AuthService } from './auth.service';
+import { NicknameService } from './nickname.service';
 import { AppStateService } from '../state/app-state.service';
 import { AppState, DailyHistoryEntry, PerScriptStat } from '../state/types';
 
@@ -38,6 +39,7 @@ import { AppState, DailyHistoryEntry, PerScriptStat } from '../state/types';
 export class UserDocService {
   private readonly auth = inject(AuthService);
   private readonly appState = inject(AppStateService);
+  private readonly nicknames = inject(NicknameService);
   private readonly db: Firestore | null;
 
   /** Uid della sessione attualmente in sync. Quando cambia (login / logout)
@@ -96,12 +98,39 @@ export class UserDocService {
       const snap = await getDoc(ref);
       if (!snap.exists()) {
         // Primo accesso assoluto per questo account: cloud non sa niente,
-        // scriviamo lo stato locale corrente come "punto zero".
+        // scriviamo lo stato locale corrente come "punto zero". Prima pero'
+        // claimiamo un nickname libero: il seed e' quello tentativo gia'
+        // settato da AppStateService (displayName Google o email-prefix);
+        // se occupato, findAvailable trova alessio.pes2, ...3, o un suffix
+        // random.
         const local = this.appState.state();
+        const seed = local.account?.nickname ?? user.displayName ?? 'lettore';
+        let claimedNick = seed;
+        try {
+          claimedNick = await this.nicknames.findAvailable(seed, user.uid);
+        } catch (e) {
+          console.warn('[firestore] nickname claim failed, using seed as-is:', e);
+        }
+        if (claimedNick !== local.account?.nickname) {
+          // Aggiorna lo stato locale prima di scrivere su /users, cosi' i due
+          // resteranno consistenti.
+          this.applyingMerge = true;
+          try {
+            this.appState.updateAccount({ nickname: claimedNick });
+          } finally {
+            queueMicrotask(() => {
+              this.applyingMerge = false;
+            });
+          }
+        }
+        const updatedLocal = {
+          ...local,
+          account: local.account ? { ...local.account, nickname: claimedNick } : local.account,
+        };
         await setDoc(
           ref,
           {
-            ...toCloudShape(local, user),
+            ...toCloudShape(updatedLocal, user),
             joinedAt: serverTimestamp(),
             updatedAt: serverTimestamp(),
           },

--- a/src/app/features/profile/profile.css
+++ b/src/app/features/profile/profile.css
@@ -4,14 +4,25 @@
   padding-bottom: 32px;
 }
 
-/* Hero: avatar grande centrato + nickname + email + chip azioni. */
+/* Hero: avatar grande centrato + nickname + email + iscritto.
+   Gap aumentato per dare aria tra avatar, nickname, email, data di
+   iscrizione: prima era 12px e i quattro elementi sembravano impilati. */
 .profile-hero {
   text-align: center;
-  padding: 12px 0 8px;
+  padding: 14px 0 10px;
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 12px;
+  gap: 16px;
+}
+/* Sotto al nickname (h2) email + joined sono due righe affini, le teniamo
+   piu' vicine fra loro (margin top negativo che compensa il gap della hero)
+   per leggerle come "metadata" di una stessa cosa. */
+.profile-email {
+  margin-top: -10px;
+}
+.profile-joined {
+  margin-top: -10px;
 }
 
 .profile-avatar-btn {
@@ -87,12 +98,27 @@
 }
 
 /* Edit mode: input largo come l'h2, bottone OK accanto. */
+.profile-nick-edit-wrap {
+  width: 100%;
+  max-width: 260px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin: 0 auto;
+}
 .profile-nick-edit {
   display: flex;
   align-items: stretch;
   gap: 8px;
-  max-width: 260px;
   width: 100%;
+}
+/* Errore "gia' preso": testo danger sotto l'input. */
+.profile-nick-error {
+  margin: 0;
+  font-size: 12px;
+  color: var(--danger);
+  text-align: left;
+  line-height: 1.4;
 }
 .profile-nick-edit .input-field {
   flex: 1;
@@ -116,11 +142,9 @@
 
 .profile-email {
   font-size: 11px;
-  margin: 0;
 }
 .profile-joined {
   font-size: 12px;
-  margin: 0;
 }
 
 .profile-anon-hint {
@@ -192,13 +216,13 @@
   border-color: var(--accent);
 }
 
-/* Chip orizzontali sotto la hero (per ora portano alle pagine ComingSoon). */
+/* Chip orizzontali sotto la hero, centrate e separate da quest'ultima. */
 .profile-chips {
   display: flex;
   gap: 8px;
   justify-content: center;
   flex-wrap: wrap;
-  margin-top: 4px;
+  margin-top: 18px;
 }
 
 /* Stats 2x2 (vs la home che e' 1x3): bestStreak + streak + accuracy + played. */

--- a/src/app/features/profile/profile.html
+++ b/src/app/features/profile/profile.html
@@ -30,19 +30,38 @@
 
       @if (account(); as a) {
         @if (editingNick()) {
-          <div class="profile-nick-edit">
-            <input
-              class="input-field"
-              type="text"
-              autofocus
-              [ngModel]="nickDraft()"
-              (ngModelChange)="nickDraft.set($event)"
-              (keydown.enter)="saveNick()"
-              (keydown.escape)="cancelEditNick()"
-              maxlength="24"
-              minlength="2"
-            />
-            <button class="btn btn-primary profile-nick-save" type="button" (click)="saveNick()">OK</button>
+          <div class="profile-nick-edit-wrap">
+            <div class="profile-nick-edit">
+              <input
+                class="input-field"
+                type="text"
+                autofocus
+                [ngModel]="nickDraft()"
+                (ngModelChange)="setNickDraft($event)"
+                (keydown.enter)="saveNick()"
+                (keydown.escape)="cancelEditNick()"
+                maxlength="24"
+                minlength="2"
+                [disabled]="nickStatus() === 'saving'"
+              />
+              <button class="btn btn-primary profile-nick-save"
+                      type="button"
+                      [disabled]="nickStatus() === 'saving' || nickDraft().trim().length < 2"
+                      (click)="saveNick()">
+                @if (nickStatus() === 'saving') {
+                  {{ i18n.lang() === 'it' ? '...' : '...' }}
+                } @else {
+                  OK
+                }
+              </button>
+            </div>
+            @if (nickStatus() === 'taken') {
+              <p class="profile-nick-error" role="alert">
+                {{ i18n.lang() === 'it'
+                  ? 'Questo nickname e\' gia\' preso, sceglierne un altro.'
+                  : 'This nickname is already taken, please pick another.' }}
+              </p>
+            }
           </div>
         } @else {
           <button
@@ -75,12 +94,12 @@
     </div>
 
     @if (account()) {
-      <!-- Azione rapida: porta alla classifica (per ora ComingSoon). La chip
-           "Profilo pubblico" l'abbiamo tolta da qui: visitare la pagina del
-           proprio profilo pubblico dal proprio profilo era un giro a vuoto.
-           La pagina /u/:nickname esiste lo stesso per quando ti capita il link
-           del profilo di qualcun altro (dalla classifica futura). -->
+      <!-- Azioni rapide affiancate: profilo pubblico (la pagina che vedono
+           gli altri) e classifica (ancora ComingSoon). -->
       <div class="profile-chips">
+        <button class="nav-btn" type="button" (click)="goPublicProfile()">
+          {{ i18n.lang() === 'it' ? 'Profilo pubblico' : 'Public profile' }}
+        </button>
         <button class="nav-btn" type="button" (click)="goLeaderboard()">
           {{ i18n.t('leaderboard') }}
         </button>

--- a/src/app/features/profile/profile.ts
+++ b/src/app/features/profile/profile.ts
@@ -5,6 +5,7 @@ import { Router } from '@angular/router';
 import { I18nService } from '../../core/i18n/i18n.service';
 import { AppStateService } from '../../core/state/app-state.service';
 import { AuthService } from '../../core/firebase/auth.service';
+import { NicknameService } from '../../core/firebase/nickname.service';
 import { AVATARS, avatarById } from '../../core/data/avatars';
 import { scriptById } from '../../core/data/scripts';
 import { computeBadges } from '../../core/data/badges';
@@ -25,6 +26,7 @@ export class Profile {
   protected readonly i18n = inject(I18nService);
   protected readonly appState = inject(AppStateService);
   private readonly authSvc = inject(AuthService);
+  private readonly nicknames = inject(NicknameService);
 
   protected readonly state = this.appState.state;
   protected readonly avatars = AVATARS;
@@ -35,6 +37,8 @@ export class Profile {
   /** Editor inline del nickname: input + tasto OK. */
   protected readonly editingNick = signal(false);
   protected readonly nickDraft = signal('');
+  /** Stato del salvataggio nickname: 'idle' | 'saving' | 'taken'. */
+  protected readonly nickStatus = signal<'idle' | 'saving' | 'taken'>('idle');
 
   /** Modale di scelta avatar. `pendingAvatar` tiene la selezione provvisoria
    *  mentre la modale e' aperta: l'utente puo' cliccare avatar diversi per
@@ -100,18 +104,49 @@ export class Profile {
     const a = this.account();
     if (!a) return;
     this.nickDraft.set(a.nickname);
+    this.nickStatus.set('idle');
     this.editingNick.set(true);
   }
 
-  protected saveNick(): void {
+  /** Salva il nuovo nickname: lo claima atomicamente su Firestore via
+   *  NicknameService. Se gia' preso, mostra "taken" come stato e l'utente puo'
+   *  cambiarne uno diverso senza chiudere l'editor. */
+  protected async saveNick(): Promise<void> {
     const v = this.nickDraft().trim();
-    if (v.length < 2 || v.length > 24) return;
-    this.appState.updateAccount({ nickname: v });
-    this.editingNick.set(false);
+    const a = this.account();
+    if (!a || v.length < 2 || v.length > 24) return;
+    if (v === a.nickname) {
+      this.editingNick.set(false);
+      return;
+    }
+    this.nickStatus.set('saving');
+    try {
+      const r = await this.nicknames.change(a.nickname, v, a.uid);
+      if (r === 'taken') {
+        this.nickStatus.set('taken');
+        return;
+      }
+      // OK: la transazione ha gia' aggiornato /users/{uid}.nickname su cloud.
+      // Aggiorniamo anche lo stato locale per la UI immediata.
+      this.appState.updateAccount({ nickname: v });
+      this.nickStatus.set('idle');
+      this.editingNick.set(false);
+    } catch (e) {
+      console.warn('[nickname] change error:', e);
+      this.nickStatus.set('idle');
+    }
   }
 
   protected cancelEditNick(): void {
     this.editingNick.set(false);
+    this.nickStatus.set('idle');
+  }
+
+  /** Quando l'utente edita il draft dopo un "taken", torniamo a 'idle' per
+   *  rimuovere il messaggio d'errore e permettere un nuovo salva. */
+  protected setNickDraft(v: string): void {
+    this.nickDraft.set(v);
+    if (this.nickStatus() === 'taken') this.nickStatus.set('idle');
   }
 
   protected openAvatarPicker(): void {

--- a/src/app/features/public-profile/public-profile.css
+++ b/src/app/features/public-profile/public-profile.css
@@ -1,0 +1,196 @@
+.pub-page {
+  display: flex;
+  flex-direction: column;
+  padding-bottom: 32px;
+}
+
+.pub-loading {
+  text-align: center;
+  padding: 40px 0;
+}
+
+.pub-notfound {
+  text-align: center;
+  padding: 40px 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+}
+.pub-notfound .muted {
+  max-width: 320px;
+  font-size: 14px;
+}
+
+/* Hero: avatar grande 96px + nickname + joined date, centrati. */
+.pub-hero {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 0;
+}
+.pub-avatar {
+  display: grid;
+  place-items: center;
+  width: 96px;
+  height: 96px;
+  border-radius: 50%;
+  font-family: var(--font-glyph);
+  font-size: 48px;
+  font-weight: 500;
+  line-height: 1;
+  background: var(--surface-2);
+  color: var(--text);
+  border: 1.5px solid var(--border);
+}
+.pub-avatar.accent {
+  background: var(--accent);
+  color: var(--accent-contrast);
+  border-color: transparent;
+}
+.pub-nick {
+  margin: 6px 0 0;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+/* Pillola "tu" accanto al nickname quando l'utente sta guardando il proprio
+   profilo pubblico (in sostituzione della indicazione che prima vivendo
+   sulla URL bar). */
+.pub-you-pill {
+  font-size: 11px;
+  font-family: var(--font-mono);
+  letter-spacing: 0.04em;
+  color: var(--accent-contrast);
+  background: var(--accent);
+  padding: 2px 8px;
+  border-radius: 999px;
+  text-transform: uppercase;
+  font-weight: 600;
+  line-height: 1;
+}
+.pub-joined {
+  font-size: 13px;
+  margin: 0;
+}
+
+.pub-stats {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+  margin-top: 22px;
+}
+
+.pub-badges-count {
+  font-size: 11px;
+  color: var(--text-mute);
+}
+
+.pub-badges-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 10px;
+}
+
+.pub-section-h {
+  margin: 0 0 12px;
+}
+
+/* Lista per-scrittura: stesso pattern della pagina /profilo, non cliccabile
+   pero' (sono dati altrui, non rinviamo a /script/:id che e' il dettaglio
+   della scrittura, non del giocatore). */
+.pub-scripts {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.pub-script {
+  display: grid;
+  grid-template-columns: 36px 1fr auto;
+  gap: 12px;
+  align-items: center;
+  padding: 10px;
+  border-radius: 12px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+}
+.pub-script-glyph {
+  display: grid;
+  place-items: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 10px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  font-family: var(--font-glyph);
+  font-size: 18px;
+}
+.pub-script-body {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.pub-script-name {
+  font-size: 14px;
+  font-weight: 500;
+}
+.pub-script-bar {
+  display: block;
+  height: 4px;
+  background: var(--surface-2);
+  border-radius: 999px;
+  overflow: hidden;
+}
+.pub-script-bar i {
+  display: block;
+  height: 100%;
+  border-radius: 999px;
+  transition: width 240ms var(--tx-ease);
+}
+.pub-script-bar i[data-acc="good"] { background: var(--success); }
+.pub-script-bar i[data-acc="mid"]  { background: var(--warm); }
+.pub-script-bar i[data-acc="bad"]  { background: var(--danger); }
+.pub-script-pct {
+  font-size: 13px;
+  color: var(--text-dim);
+  font-variant-numeric: tabular-nums;
+}
+
+/* Card "Vuoi battere X?" + bottone Gioca anche tu, visibile sui profili altrui. */
+.pub-beatme {
+  margin-top: 22px;
+  padding: 14px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+}
+.pub-beatme-text {
+  margin: 0;
+  font-size: 13px;
+  color: var(--text-dim);
+}
+.pub-beatme-nick {
+  color: var(--accent);
+  font-weight: 600;
+}
+.pub-beatme-cta {
+  height: 40px;
+  padding: 0 18px;
+}
+
+/* CTA per il proprio profilo: "Condividi profilo" a tutta larghezza. */
+.pub-cta {
+  margin-top: 22px;
+}
+
+/* Tasto condividi nell'app-bar: piu' compatto. */
+.pub-share-btn {
+  height: 30px;
+  font-size: 12px;
+  padding: 0 12px;
+}

--- a/src/app/features/public-profile/public-profile.html
+++ b/src/app/features/public-profile/public-profile.html
@@ -1,0 +1,147 @@
+<div class="app-shell">
+  <app-bar [canBack]="true"
+           (back)="goBack()"
+           (goHome)="goHome()">
+    @if (profile() && !loading()) {
+      <button class="nav-btn pub-share-btn" type="button" (click)="share()">
+        @if (copyFlash()) {
+          ✓ {{ i18n.lang() === 'it' ? 'Copiato' : 'Copied' }}
+        } @else {
+          {{ i18n.lang() === 'it' ? 'Condividi' : 'Share' }}
+        }
+      </button>
+    }
+  </app-bar>
+
+  <div class="page pub-page">
+    @if (loading()) {
+      <p class="muted pub-loading">
+        {{ i18n.lang() === 'it' ? 'Caricamento…' : 'Loading…' }}
+      </p>
+    } @else if (notFound()) {
+      <div class="pub-notfound">
+        <h2 class="h2">{{ i18n.lang() === 'it' ? 'Profilo non trovato' : 'Profile not found' }}</h2>
+        <p class="muted">
+          {{ i18n.lang() === 'it'
+            ? 'Il nickname che hai aperto non esiste, oppure l\'utente l\'ha cambiato.'
+            : 'The nickname you opened doesn\'t exist, or the user has changed it.' }}
+        </p>
+        <button class="btn btn-primary" type="button" (click)="goHome()">
+          {{ i18n.t('goHome') }}
+        </button>
+      </div>
+    } @else if (profile(); as p) {
+      <div class="pub-hero">
+        <span class="pub-avatar accent">{{ avatarGlyph() }}</span>
+        <h1 class="h1 pub-nick">
+          {{ p.nickname }}
+          @if (isSelf()) {
+            <span class="pub-you-pill">{{ i18n.lang() === 'it' ? 'tu' : 'you' }}</span>
+          }
+        </h1>
+        @if (joinedLabel(); as j) {
+          <p class="muted pub-joined">
+            {{ i18n.lang() === 'it' ? 'Membro da' : 'Member since' }} {{ j }}
+          </p>
+        }
+      </div>
+
+      <!-- Stats 2x2 (best, accuracy, played, dailyStreak) -->
+      <div class="pub-stats">
+        <div class="stat">
+          <span class="v">{{ p.bestStreak }}</span>
+          <span class="l">{{ i18n.t('bestStreak') }}</span>
+        </div>
+        <div class="stat">
+          <span class="v">{{ p.accuracy }}%</span>
+          <span class="l">{{ i18n.t('accuracy') }}</span>
+        </div>
+        <div class="stat">
+          <span class="v">{{ p.played }}</span>
+          <span class="l">{{ i18n.t('played') }}</span>
+        </div>
+        <div class="stat">
+          <span class="v">{{ p.dailyStreak }}</span>
+          <span class="l">{{ i18n.lang() === 'it' ? 'Giorni di fila' : 'Daily streak' }}</span>
+        </div>
+      </div>
+
+      <div class="divider"></div>
+
+      <h3 class="h3 pub-section-h">
+        {{ i18n.lang() === 'it' ? 'Per scrittura' : 'By script' }}
+      </h3>
+      @if (p.scriptStats.length === 0) {
+        <p class="muted">
+          {{ i18n.lang() === 'it'
+            ? 'Nessun progresso ancora su nessuna scrittura.'
+            : 'No progress on any script yet.' }}
+        </p>
+      } @else {
+        <div class="pub-scripts">
+          @for (e of p.scriptStats; track e.id) {
+            <div class="pub-script">
+              <span class="pub-script-glyph">{{ e.script.sample }}</span>
+              <div class="pub-script-body">
+                <span class="pub-script-name">
+                  {{ i18n.lang() === 'it' ? e.script.nameIt : e.script.nameEn }}
+                </span>
+                <span class="pub-script-bar">
+                  <i [style.width.%]="e.acc" [attr.data-acc]="accLevel(e.acc)"></i>
+                </span>
+              </div>
+              <span class="pub-script-pct mono">{{ e.acc }}%</span>
+            </div>
+          }
+        </div>
+      }
+
+      <div class="divider"></div>
+
+      <div class="section-head">
+        <h3 class="h3">
+          {{ i18n.lang() === 'it' ? 'Traguardi sbloccati' : 'Unlocked badges' }}
+        </h3>
+        <span class="mono pub-badges-count">
+          {{ p.unlockedBadges.length }}/{{ p.totalBadges }}
+        </span>
+      </div>
+      @if (p.unlockedBadges.length === 0) {
+        <p class="muted">
+          {{ i18n.lang() === 'it' ? 'Nessun traguardo ancora.' : 'No badges yet.' }}
+        </p>
+      } @else {
+        <div class="pub-badges-grid">
+          @for (b of p.unlockedBadges; track b.id) {
+            <div class="badge-card" data-unlocked="1" [attr.data-tier]="b.tier"
+                 [attr.aria-label]="i18n.lang() === 'it' ? b.titleIt : b.titleEn">
+              <span class="badge-icon">{{ b.icon }}</span>
+              <span class="badge-title">{{ i18n.lang() === 'it' ? b.titleIt : b.titleEn }}</span>
+            </div>
+          }
+        </div>
+      }
+
+      <!-- CTA in fondo: "Condividi profilo" se tu, "Gioca anche tu" se altri. -->
+      @if (isSelf()) {
+        <button class="btn btn-primary btn-block pub-cta" type="button" (click)="share()">
+          @if (copyFlash()) {
+            ✓ {{ i18n.lang() === 'it' ? 'Link copiato' : 'Link copied' }}
+          } @else {
+            {{ i18n.lang() === 'it' ? 'Condividi profilo' : 'Share profile' }}
+          }
+        </button>
+      } @else {
+        <div class="card pub-beatme">
+          <p class="pub-beatme-text">
+            {{ i18n.lang() === 'it' ? 'Vuoi battere' : 'Want to beat' }}
+            <span class="pub-beatme-nick">{{ p.nickname }}</span>?
+          </p>
+          <button class="btn btn-primary pub-beatme-cta" type="button" (click)="goPlay()">
+            {{ i18n.lang() === 'it' ? 'Gioca anche tu' : 'Play too' }}
+          </button>
+        </div>
+      }
+    }
+  </div>
+</div>

--- a/src/app/features/public-profile/public-profile.ts
+++ b/src/app/features/public-profile/public-profile.ts
@@ -1,0 +1,213 @@
+import { ChangeDetectionStrategy, Component, computed, effect, inject, signal } from '@angular/core';
+import { Location } from '@angular/common';
+import { ActivatedRoute, Router } from '@angular/router';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { map } from 'rxjs/operators';
+import { I18nService } from '../../core/i18n/i18n.service';
+import { AppStateService } from '../../core/state/app-state.service';
+import { NicknameService } from '../../core/firebase/nickname.service';
+import { avatarById } from '../../core/data/avatars';
+import { BadgeWithProgress, computeBadges } from '../../core/data/badges';
+import { ScriptInfo, scriptById } from '../../core/data/scripts';
+import { AppBar } from '../../shared/app-bar';
+import { AppState, DEFAULT_STATE } from '../../core/state/types';
+
+/**
+ * Profilo pubblico mostrato a `/u/:nickname`. Funziona sia per il proprio
+ * profilo (mostra "tu" + tasto Condividi) sia per quello di altri utenti
+ * (mostra CTA "Gioca anche tu"). Legge da Firestore via NicknameService;
+ * niente real-time, una sola fetch all'ingresso (e su cambio param).
+ */
+@Component({
+  selector: 'app-public-profile',
+  imports: [AppBar],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './public-profile.html',
+  styleUrl: './public-profile.css',
+})
+export class PublicProfile {
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+  private readonly location = inject(Location);
+  protected readonly i18n = inject(I18nService);
+  protected readonly appState = inject(AppStateService);
+  private readonly nicknames = inject(NicknameService);
+
+  /** Param `:nickname` dalla rotta, in formato URL-encoded come arriva. */
+  protected readonly nickname = toSignal(
+    this.route.paramMap.pipe(map((p) => p.get('nickname') ?? '')),
+    { initialValue: '' },
+  );
+
+  protected readonly loading = signal(false);
+  protected readonly notFound = signal(false);
+  protected readonly profile = signal<PublicProfileData | null>(null);
+  protected readonly copyFlash = signal(false);
+
+  protected readonly isSelf = computed(() => {
+    const p = this.profile();
+    const me = this.appState.state().account?.uid;
+    return !!(p && me && p.uid === me);
+  });
+
+  protected readonly profileUrl = computed(() => {
+    if (typeof window === 'undefined') return '';
+    return `${window.location.origin}${window.location.pathname.replace(/\/u\/.*$/, '')}/u/${this.nickname()}`;
+  });
+
+  protected readonly avatarGlyph = computed(() => {
+    return avatarById(this.profile()?.avatar ?? 0).glyph;
+  });
+
+  protected readonly joinedLabel = computed(() => {
+    const ts = this.profile()?.joinedAt;
+    if (!ts) return '';
+    // Firestore Timestamp ha .toDate(); fallback a stringa ISO.
+    let d: Date;
+    if (typeof (ts as { toDate?: () => Date })?.toDate === 'function') {
+      d = (ts as { toDate: () => Date }).toDate();
+    } else if (typeof ts === 'string') {
+      d = new Date(ts);
+    } else {
+      return '';
+    }
+    if (Number.isNaN(d.getTime())) return '';
+    const locale = this.i18n.lang() === 'it' ? 'it-IT' : 'en-GB';
+    return d.toLocaleDateString(locale, { month: 'long', year: 'numeric' });
+  });
+
+  constructor() {
+    // Quando cambia il nickname nell'URL (o al primo entry) facciamo fetch.
+    effect(() => {
+      const n = this.nickname();
+      if (!n) return;
+      this.loading.set(true);
+      this.notFound.set(false);
+      this.profile.set(null);
+      void this.fetch(n);
+    });
+  }
+
+  private async fetch(nick: string): Promise<void> {
+    try {
+      const doc = await this.nicknames.getUserByNickname(nick);
+      if (!doc) {
+        this.notFound.set(true);
+        return;
+      }
+      // Ricostruisce un AppState parziale per usare computeBadges sui dati cloud.
+      const stateForBadges: AppState = {
+        ...DEFAULT_STATE,
+        streak: (doc as Record<string, number>)['streak'] ?? 0,
+        bestStreak: (doc as Record<string, number>)['bestStreak'] ?? 0,
+        played: (doc as Record<string, number>)['played'] ?? 0,
+        correctAnswers: (doc as Record<string, number>)['correctAnswers'] ?? 0,
+        accuracy: (doc as Record<string, number>)['accuracy'] ?? 0,
+        perScript: (doc as Record<string, AppState['perScript']>)['perScript'] ?? {},
+        dailyDone: (doc as Record<string, boolean>)['dailyDone'] ?? false,
+        dailyDoneStamp: (doc as Record<string, string | null>)['dailyDoneStamp'] ?? null,
+        dailyScore: (doc as Record<string, number>)['dailyScore'] ?? 0,
+        dailyStreak: (doc as Record<string, number>)['dailyStreak'] ?? 0,
+        dailyHistory: (doc as Record<string, AppState['dailyHistory']>)['dailyHistory'] ?? [],
+      };
+      const allBadges = computeBadges(stateForBadges);
+      const unlockedBadges = allBadges.filter((b) => b.unlocked);
+      // Stats per-scrittura calcolate dai perScript cloud, ordinate per
+      // accuratezza desc (come nella propria pagina /profilo).
+      const scriptStats = Object.entries(stateForBadges.perScript)
+        .map(([id, v]) => ({
+          id,
+          tries: v.tries,
+          correct: v.correct,
+          acc: v.tries > 0 ? Math.round((100 * v.correct) / v.tries) : 0,
+          script: scriptById(id),
+        }))
+        .filter((e): e is typeof e & { script: ScriptInfo } =>
+          e.tries >= 1 && e.script != null,
+        )
+        .sort((a, b) => b.acc - a.acc);
+      this.profile.set({
+        uid: doc.uid,
+        nickname: (doc as Record<string, string>)['nickname'] ?? nick,
+        avatar: (doc as Record<string, number>)['avatar'] ?? 0,
+        joinedAt: doc['joinedAt'],
+        bestStreak: stateForBadges.bestStreak,
+        accuracy: stateForBadges.accuracy,
+        played: stateForBadges.played,
+        dailyStreak: stateForBadges.dailyStreak,
+        unlockedBadges,
+        totalBadges: allBadges.length,
+        scriptStats,
+      });
+    } catch (e) {
+      console.warn('[public-profile] fetch error:', e);
+      this.notFound.set(true);
+    } finally {
+      this.loading.set(false);
+    }
+  }
+
+  protected async share(): Promise<void> {
+    const url = this.profileUrl();
+    const p = this.profile();
+    if (!url || !p) return;
+    const text =
+      this.i18n.lang() === 'it'
+        ? `${p.nickname} su Indovina il carattere`
+        : `${p.nickname} on Guess the Char`;
+    try {
+      if (typeof navigator !== 'undefined' && typeof navigator.share === 'function') {
+        await navigator.share({ url, text });
+        return;
+      }
+    } catch {
+      // Utente ha annullato lo share sheet: ignoriamo silenziosamente.
+    }
+    // Fallback: copia negli appunti.
+    try {
+      await navigator.clipboard.writeText(url);
+      this.copyFlash.set(true);
+      setTimeout(() => this.copyFlash.set(false), 1600);
+    } catch {
+      // ignore
+    }
+  }
+
+  protected goPlay(): void {
+    this.router.navigate(['/home']);
+  }
+
+  protected accLevel(pct: number): 'good' | 'mid' | 'bad' {
+    if (pct >= 75) return 'good';
+    if (pct >= 40) return 'mid';
+    return 'bad';
+  }
+
+  protected goBack(): void {
+    this.location.back();
+  }
+
+  protected goHome(): void {
+    this.router.navigate(['/home']);
+  }
+}
+
+interface PublicProfileData {
+  uid: string;
+  nickname: string;
+  avatar: number;
+  joinedAt: unknown;
+  bestStreak: number;
+  accuracy: number;
+  played: number;
+  dailyStreak: number;
+  unlockedBadges: BadgeWithProgress[];
+  totalBadges: number;
+  scriptStats: Array<{
+    id: string;
+    tries: number;
+    correct: number;
+    acc: number;
+    script: ScriptInfo;
+  }>;
+}


### PR DESCRIPTION
Due cose strettamente legate: nickname unico tra utenti, e pagina /u/nickname pubblica.

Nickname unico

Nuovo NicknameService che gestisce la collezione /nicknames/{nick_lowercased} su Firestore. Metodi: claim atomico, change atomico (rilascio del vecchio + claim del nuovo + update di /users/{uid}.nickname in una sola transazione), findAvailable che prova seed, seed2, ..., seed5, poi fallback seed-rnd4chars, getUserByNickname per il profilo pubblico.

Al primo signup, UserDocService.onLogin ora chiama findAvailable col nickname seedato (displayName Google o email-prefix). Se libero lo claim subito. Se occupato, l'utente si ritrova alessio.pes2 invece di alessio.pes. Lo stato locale viene aggiornato con il nickname effettivamente claimed prima della scrittura su /users, cosi' i due restano consistenti.

Al cambio nickname dal profilo, Profile.saveNick chiama nicknames.change(oldNick, newNick, uid). Se la transazione torna 'taken' mostra "Questo nickname e' gia' preso, sceglierne un altro" sotto l'input (testo danger), l'editor resta aperto. Se 'ok' aggiorna lo state locale e chiude. Indicatori UI: bottone OK mostra '...' durante il saving, disabilitato se draft < 2 chars.

Le regole Firestore deployate in PR #46 gia' coprono /nicknames: read pubblica, create con uid match, update mai consentito (devi cancellare e ricreare), delete solo dal proprietario. La transazione fa tutto in un unico round-trip, niente race.

Pagina /u/nickname

Sostituisce il ComingSoon per la rotta. Componente PublicProfile, lazy-loaded. Legge :nickname dal route param via toSignal(paramMap), fa fetch via NicknameService.getUserByNickname (due step: /nicknames/{nick} -> uid -> /users/{uid}). Rendering: pillola TU accanto al nickname se isSelf, avatar 96px accent, Membro da MMMM YYYY (parse del Firestore Timestamp via toDate()), stats 2x2 best/accuracy/played/dailyStreak, sezione Per scrittura (stesso pattern del /profilo: glifo + nome + barra colorata + percentuale), griglia 4-col dei badge sbloccati con count X/Y nell'header.

CTA in fondo cambia in base a isSelf: per il tuo profilo Condividi profilo che apre navigator.share o copia il link negli appunti (flash Link copiato per 1.6s); per il profilo di altri Vuoi battere X? Gioca anche tu con bottone che porta a /home.

Niente real-time. Quando navighi a /u/altro-nickname la pagina si rinfresca; se durante la visita l'altro utente cambia nickname, te ne accorgi al prossimo reload.

Su tutta la pagina: gestione del notFound (nickname che non esiste o /users mancante) con messaggio e CTA Vai alla home.

Dalla pagina /profilo: bottone Profilo pubblico riapparso accanto a Classifica. Va a /u/{tuo-nickname} che mostra la tua scheda pubblica con la pillola TU.

Polish hero /profilo

Avatar -> nickname -> email -> Iscritto da ora hanno piu' aria (gap 16px invece di 12px nella flex column). Email e data iscrizione restano vicini fra loro come "metadata" del nickname (margin-top negativo che compensa il gap). Le chip Profilo pubblico/Classifica partono 18px sotto la hero invece di 4px per separare nettamente identita' da azioni.

Cosa NON in questa PR

Real-time sync dei profili (servirebbe firebase/firestore completo, no lite). La /leaderboard ancora ComingSoon: e' la prossima destinazione naturale (e a quel punto si potra' cliccare un nickname dalla classifica per atterrare sul profilo pubblico).