### PR TITLE
fix(settings): card profilo cliccabile + pulizia placeholder e emoji

### DIFF
--- a/src/app/features/settings/settings.css
+++ b/src/app/features/settings/settings.css
@@ -63,6 +63,34 @@
   padding: 0 14px;
 }
 
+/* Quando sei loggato, l'area avatar+nick+email e' un bottone cliccabile che
+   porta al profilo. Stile flat/trasparente: l'aspetto resta uguale alla card,
+   solo l'hover/active aggiunge un velo per indicare l'interattivita'. */
+.account-card-trigger {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  padding: 0;
+  margin: -6px -8px;
+  border-radius: 10px;
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  cursor: pointer;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  transition: background var(--hover-dur) ease;
+}
+.account-card-trigger:hover {
+  background: var(--surface-2);
+}
+.account-card-trigger .account-avatar {
+  margin-left: 8px;
+}
+
 /* Una "settings-section" e' una colonna di righe (setting-row, toggle-row, help-btn). */
 .settings-section {
   display: flex;
@@ -213,10 +241,6 @@
   border-color: var(--border-strong);
   transform: translateY(-1px);
 }
-.help-emoji {
-  font-size: 16px;
-  line-height: 1;
-}
 .help-label {
   flex: 1;
 }
@@ -227,24 +251,6 @@
 .data-blurb {
   font-size: 13px;
   line-height: 1.5;
-  margin: 0;
-}
-
-/* Card del codice di sincronizzazione: rivelata al click. Placeholder per ora. */
-.sync-card {
-  text-align: center;
-  padding: 14px;
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-.sync-code {
-  font-size: 22px;
-  font-weight: 600;
-  letter-spacing: 0.2em;
-}
-.sync-foot {
-  font-size: 11px;
   margin: 0;
 }
 

--- a/src/app/features/settings/settings.html
+++ b/src/app/features/settings/settings.html
@@ -2,17 +2,20 @@
   <app-bar [canBack]="true" [title]="i18n.t('settings')" (back)="goBack()" (goHome)="goHome()" />
 
   <div class="page settings-page">
-    <!-- Card account: stato connesso vs anonimo. Per ora solo il caso "non
-         connesso" e' realmente raggiungibile (la pagina /login viene aggiunta
-         in PR 3). Quando ci sara' un account vero, la card mostra avatar,
-         nickname e link al profilo. -->
+    <!-- Card account: stato connesso vs anonimo. Quando sei loggato, l'area
+         avatar + nickname + email e' un bottone cliccabile che porta al
+         profilo; il tasto Esci resta separato sulla destra cosi' non si
+         attiva per sbaglio. -->
     <div class="card account-card">
       @if (state().account; as a) {
-        <span class="account-avatar accent">{{ a.nickname.charAt(0).toUpperCase() }}</span>
-        <div class="account-meta">
-          <span class="account-name">{{ a.nickname }}</span>
-          <span class="account-sub mono">{{ a.email }}</span>
-        </div>
+        <button class="account-card-trigger" type="button" (click)="goProfile()"
+                [attr.aria-label]="i18n.lang() === 'it' ? 'Vai al profilo' : 'Open profile'">
+          <span class="account-avatar accent">{{ a.nickname.charAt(0).toUpperCase() }}</span>
+          <div class="account-meta">
+            <span class="account-name">{{ a.nickname }}</span>
+            <span class="account-sub mono">{{ a.email }}</span>
+          </div>
+        </button>
         <button class="nav-btn account-logout" type="button" (click)="signOut()">
           {{ i18n.t('logout') }}
         </button>
@@ -139,14 +142,12 @@
     <h3 class="h3 section-h">{{ i18n.lang() === 'it' ? 'Aiuto' : 'Help' }}</h3>
     <div class="settings-section">
       <button class="help-btn" type="button" (click)="goFeedback()">
-        <span class="help-emoji">💬</span>
         <span class="help-label">
           {{ i18n.lang() === 'it' ? 'Segnala bug o suggerisci un’idea' : 'Report a bug or suggest an idea' }}
         </span>
         <app-icon name="chev" />
       </button>
       <button class="help-btn" type="button" (click)="replayOnboarding()">
-        <span class="help-emoji">🎬</span>
         <span class="help-label">
           {{ i18n.lang() === 'it' ? 'Rivedi la presentazione' : 'Replay the intro' }}
         </span>
@@ -169,22 +170,6 @@
             : 'Your progress is stored on this device only.' }}
         }
       </p>
-
-      @if (!showSync()) {
-        <button class="btn btn-ghost btn-block" type="button" (click)="revealSync()">
-          {{ i18n.lang() === 'it' ? 'Mostra codice di sincronizzazione' : 'Show sync code' }}
-        </button>
-      } @else {
-        <div class="card sync-card">
-          <span class="eyebrow">
-            {{ i18n.lang() === 'it' ? 'CODICE DI SINCRONIZZAZIONE' : 'SYNC CODE' }}
-          </span>
-          <div class="sync-code mono">{{ syncCode() }}</div>
-          <p class="muted sync-foot">
-            {{ i18n.lang() === 'it' ? 'Funzione in arrivo · placeholder' : 'Coming soon · placeholder' }}
-          </p>
-        </div>
-      }
 
       <button class="btn btn-ghost btn-block reset-btn" type="button" (click)="resetProgress()">
         {{ i18n.lang() === 'it' ? 'Azzera progressi' : 'Reset progress' }}

--- a/src/app/features/settings/settings.ts
+++ b/src/app/features/settings/settings.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { Location } from '@angular/common';
 import { Router } from '@angular/router';
 import { I18nService } from '../../core/i18n/i18n.service';
@@ -37,12 +37,6 @@ export class Settings {
   protected readonly cbModes: ReadonlyArray<ColorblindMode> = ['none', 'redgreen', 'blueyellow'];
   protected readonly langs: ReadonlyArray<Lang> = ['it', 'en'];
 
-  /** La card del codice di sincronizzazione e' chiusa per default; il tasto
-   *  "Mostra codice di sincronizzazione" la rivela. Una volta rivelata, il
-   *  codice viene generato in localStorage e resta stabile tra sessioni. */
-  protected readonly showSync = signal(false);
-  protected readonly syncCode = computed(() => (this.showSync() ? ensureSyncCode() : ''));
-
   /** Footer in fondo: in dev include l'hash, in release no. */
   protected readonly buildLabel =
     BUILD_CONTEXT === 'release' ? `v${APP_VERSION}` : `v${APP_VERSION} · dev · ${BUILD_SHA}`;
@@ -68,10 +62,6 @@ export class Settings {
   }
   protected toggleShowCodepoint(): void {
     this.appState.update({ showCodepoint: !this.state().showCodepoint });
-  }
-
-  protected revealSync(): void {
-    this.showSync.set(true);
   }
 
   protected goFeedback(): void {
@@ -140,28 +130,5 @@ export class Settings {
 
   protected goHome(): void {
     this.router.navigate(['/home']);
-  }
-}
-
-/**
- * Codice di sincronizzazione "mock" (8 caratteri, divisi 4-4, alfabeto safe
- * senza I/O/0/1). Persistito in localStorage cosi' che, una volta generato,
- * resta stabile tra sessioni come si comporterebbe un vero codice di pairing.
- * Sara' rimpiazzato dal vero meccanismo quando integreremo il BaaS.
- */
-function ensureSyncCode(): string {
-  try {
-    const cached = localStorage.getItem('gtc.sync');
-    if (cached) return cached;
-    const alphabet = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
-    let raw = '';
-    for (let i = 0; i < 8; i++) {
-      raw += alphabet[Math.floor(Math.random() * alphabet.length)];
-    }
-    const code = `${raw.slice(0, 4)}-${raw.slice(4)}`;
-    localStorage.setItem('gtc.sync', code);
-    return code;
-  } catch {
-    return 'XXXX-XXXX';
   }
 }


### PR DESCRIPTION
Quattro piccoli ritocchi alla pagina impostazioni, tutti scoperti girando l'app dopo aver mergiato il profilo vero.

In cima alla pagina, la card account con avatar, nickname ed email ora e' cliccabile per intero e ti porta su /profilo. Prima l'unica zona attiva era il pulsante Esci a destra: cliccando sul nome o sull'email non succedeva nulla. Esci resta separato per evitare disconnessioni accidentali col dito.

I due bottoni della sezione Aiuto (Segnala bug, Rivedi la presentazione) avevano davanti un'emoticon (💬 e 🎬) che era visivamente fuori scala rispetto al resto dei controlli dell'app. Tolte: ora ci sono solo il testo della voce a sinistra e la freccia chevron a destra, in linea con le altre liste cliccabili dell'app.

Rimossa anche tutta la sezione "Mostra codice di sincronizzazione": era una mock-feature del prototipo Claude Design che rivelava un codice fittizio di 8 caratteri con la dicitura "Funzione in arrivo, placeholder". Oggi la sincronizzazione vera passa dall'account utente (PR #49), un codice di pairing visivo non serve piu'. Eliminato anche l'helper ensureSyncCode + signal showSync + relativi CSS .sync-card/.sync-code/.sync-foot.

Piccolo dettaglio: il chevron > che avevo aggiunto come "indicatore tappabile" sulla nuova card profilo cliccabile in cima non piaceva, l'ho tolto. Il fatto che cliccando sulla zona si apre /profilo si capisce dal cambio di background al hover.