### PR TITLE
feat(search): pagina cerca utenti con fuzzy matching

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,7 @@ src/
       profile/
       public-profile/
       script-detail/
+      search/
       selection/
       session-result/
       settings/
@@ -299,6 +300,7 @@ L'app si appoggia a Firebase Auth + Firestore per login e sincronizzazione del p
 - `src/app/core/firebase/auth.service.ts`: `AuthService` con signal `user` (`User | null | 'loading'`), `enabled` (boolean), metodi `signInEmail/signUpEmail/signInGoogle/signOut`. Quando `enabled === false` i metodi rigettano con `AuthDisabledError`.
 - `src/app/core/firebase/user-doc.service.ts`: `UserDocService` che sincronizza lo stato di gioco con `/users/{uid}` su Firestore quando l'utente e' loggato. Bootstrap-attivato (inject dummy in `App`). All'auth.user che diventa autenticato fa max-merge tra locale e cloud; al primo signup chiama `NicknameService.findAvailable` per claimare un nickname unico. Ad ogni cambio di state mentre loggato, push debounced di 1s. Usa `firebase/firestore/lite` (no real-time, no offline persistence) per tenere il bundle sotto i 500kB.
 - `src/app/core/firebase/nickname.service.ts`: `NicknameService` gestisce la collezione `/nicknames/{nick_lowercased}` per garantire l'unicita' del nickname. Metodi: `claim(nick, uid)` atomica via runTransaction, `change(oldNick, newNick, uid)` swap atomico (release vecchio + claim nuovo + update `/users/{uid}.nickname` in una sola transazione), `findAvailable(seed, uid)` cerca varianti seed/seed2/seed3/.../seed-rnd, `getUserByNickname(nick)` per il profilo pubblico.
+- `src/app/core/firebase/user-search.service.ts`: `UserSearchService` cerca utenti per nickname con tolleranza fuzzy (Levenshtein <=2). Carica la collezione `/nicknames` intera in cache (TTL 5 min) e fa filtering/ranking client-side: match esatto > prefisso > sottostringa > distanza 1 > distanza 2. Strategia OK fino a ~2000 utenti; oltre, conviene un indice esterno tipo Algolia.
 - `AppStateService` si abbona al signal `auth.user` via `effect`: a ogni cambio di stato Auth, riflette in `state.account` (uid, email, nickname seedato da `displayName` per Google, avatar 0 di default).
 - `firestore.rules`, `firebase.json`, `.firebaserc` alla root: config per `firebase deploy`. Schema corrente: `/users/{uid}` (stato gioco + anagrafica) e `/nicknames/{nick}` (indice unicita', non ancora popolato).
 
@@ -322,7 +324,8 @@ Le scritture successive durante la sessione fanno **full overwrite** del documen
 
 - La route `/leaderboard` e' ancora `ComingSoon`. La PR che la accendera' usera' gia' lo stato Auth (`AuthService.user()`) come fonte di verita' e i progressi cloud da `/users/{uid}`.
 - `/profile` reale: hero con avatar editabile in modale (12 glifi predefiniti in `AVATARS`), nickname inline edit (Enter salva, Esc annulla, errore "gia' preso" via transazione `NicknameService.change`), stats 2x2, lista per-scrittura con barre colorate (verde >=75%, ambra >=40%, rosso <40%), badges teaser, storico daily.
-- `/u/:nickname` profilo pubblico reale: faux URL bar in cima, avatar 96px, "Membro da MMMM YYYY", stats 2x2 (best, accuracy, played, dailyStreak), griglia 4-col dei badge sbloccati. CTA in fondo cambia in base a "tu / altri": se sei tu mostra "Condividi profilo", altrimenti "Vuoi battere X? Gioca anche tu". Read pubblica via `NicknameService.getUserByNickname` (no auth richiesta, le regole Firestore permettono read pubblica su `/users` e `/nicknames`).
+- `/u/:nickname` profilo pubblico reale: pillola "TU" accanto al nome se sei tu, avatar 96px, "Membro da MMMM YYYY", stats 2x2 (best, accuracy, played, dailyStreak), lista per-scrittura con barre colorate, griglia 4-col dei badge sbloccati. CTA in fondo cambia in base a "tu / altri": se sei tu mostra "Condividi profilo", altrimenti "Vuoi battere X? Gioca anche tu". Read pubblica via `NicknameService.getUserByNickname`.
+- `/search` ricerca utenti: input con debounce 250ms, fuzzy fino a 2 errori, "X utenti trovati", risultati cliccabili che portano a `/u/:nickname`. Accessibile dal menu account della home, voce "Cerca utenti".
 
 ### Convenzioni
 

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -78,6 +78,12 @@ export const routes: Routes = [
     loadComponent: () => import('./features/profile/profile').then((m) => m.Profile),
   },
 
+  {
+    path: 'search',
+    canActivate: [onboardedGuard],
+    loadComponent: () => import('./features/search/search').then((m) => m.Search),
+  },
+
   // Aree social ancora stub: classifica, sfide tra amici.
   { path: 'leaderboard',       canActivate: [onboardedGuard], loadComponent: comingSoon },
 

--- a/src/app/core/firebase/user-search.service.ts
+++ b/src/app/core/firebase/user-search.service.ts
@@ -1,0 +1,131 @@
+import { Injectable } from '@angular/core';
+import {
+  Firestore,
+  collection,
+  getDocs,
+  getFirestore,
+  limit,
+  query,
+} from 'firebase/firestore/lite';
+import { ensureFirebaseApp } from './firebase';
+
+/**
+ * Ricerca utenti per nickname con tolleranza fuzzy (Levenshtein <=2).
+ *
+ * Strategia: la collezione `/nicknames` e' piccola (un doc per utente, ~50
+ * byte ciascuno) e leggerla in blocco e' ragionevole finche' restiamo sotto i
+ * ~2000 utenti. Carico la lista una volta a sessione (con cache TTL di 5
+ * minuti), poi tutte le ricerche successive sono client-side: niente
+ * round-trip per ogni tasto premuto, costo Firestore quasi nullo.
+ *
+ * Oltre i 2000 utenti questo approccio costerebbe troppe read per ricerca;
+ * a quel punto si passa a un indice esterno (Algolia / Typesense / Meilisearch)
+ * o a uno schema con n-gram in una collezione dedicata. Per ora overkill.
+ */
+@Injectable({ providedIn: 'root' })
+export class UserSearchService {
+  private readonly db: Firestore | null;
+  private cache: NicknameEntry[] | null = null;
+  private cacheAt = 0;
+  /** TTL della cache: oltre questo intervallo, la prossima search rilegge da Firestore. */
+  private readonly CACHE_TTL_MS = 5 * 60 * 1000;
+
+  constructor() {
+    const app = ensureFirebaseApp();
+    this.db = app ? getFirestore(app) : null;
+  }
+
+  /**
+   * Cerca utenti per nickname. Restituisce risultati ordinati per rilevanza:
+   * match esatto > prefisso > sottostringa > distanza Levenshtein crescente.
+   * Restituisce fino a `max` risultati (default 30).
+   */
+  async search(qStr: string, max = 30): Promise<NicknameEntry[]> {
+    const q = qStr.trim().toLowerCase();
+    if (q.length < 2) return [];
+    const all = await this.loadAll();
+    return rankMatches(all, q).slice(0, max);
+  }
+
+  /**
+   * Invalida la cache. Da chiamare dopo che l'utente cambia il proprio
+   * nickname, cosi' il cambio si riflette nella ricerca senza aspettare il TTL.
+   */
+  invalidateCache(): void {
+    this.cache = null;
+    this.cacheAt = 0;
+  }
+
+  private async loadAll(): Promise<NicknameEntry[]> {
+    if (this.cache && Date.now() - this.cacheAt < this.CACHE_TTL_MS) {
+      return this.cache;
+    }
+    if (!this.db) return [];
+    const ref = collection(this.db, 'nicknames');
+    const snap = await getDocs(query(ref, limit(2000)));
+    const entries: NicknameEntry[] = [];
+    snap.forEach((d) => {
+      const uid = d.data()?.['uid'];
+      if (typeof uid === 'string') entries.push({ nick: d.id, uid });
+    });
+    this.cache = entries;
+    this.cacheAt = Date.now();
+    return entries;
+  }
+}
+
+export interface NicknameEntry {
+  /** Nickname in forma lowercased (cosi' come e' la doc ID in /nicknames). */
+  nick: string;
+  /** Uid Firebase Auth dell'utente proprietario. */
+  uid: string;
+}
+
+/**
+ * Calcola uno score di rilevanza tra query e nickname. Score piu' basso = match
+ * migliore.
+ *   0  - match esatto
+ *   1  - nickname inizia con la query
+ *   2  - nickname contiene la query come sottostringa
+ *   3+ - distanza Levenshtein (3 = 1 errore, 4 = 2 errori)
+ * Tutto oltre 2 errori viene scartato.
+ */
+function rankMatches(all: NicknameEntry[], q: string): NicknameEntry[] {
+  const scored: Array<{ entry: NicknameEntry; score: number }> = [];
+  for (const e of all) {
+    const n = e.nick; // gia' lowercased (e' la doc ID)
+    let score: number;
+    if (n === q) score = 0;
+    else if (n.startsWith(q)) score = 1;
+    else if (n.includes(q)) score = 2;
+    else {
+      const d = levenshtein(q, n);
+      if (d > 2) continue;
+      score = 2 + d;
+    }
+    scored.push({ entry: e, score });
+  }
+  scored.sort(
+    (a, b) => a.score - b.score || a.entry.nick.localeCompare(b.entry.nick),
+  );
+  return scored.map((s) => s.entry);
+}
+
+/** Levenshtein distance iterativa con due righe. Char-by-char, niente Unicode special. */
+function levenshtein(a: string, b: string): number {
+  if (a === b) return 0;
+  if (a.length === 0) return b.length;
+  if (b.length === 0) return a.length;
+  let prev = new Array<number>(b.length + 1);
+  let curr = new Array<number>(b.length + 1);
+  for (let j = 0; j <= b.length; j++) prev[j] = j;
+  for (let i = 1; i <= a.length; i++) {
+    curr[0] = i;
+    for (let j = 1; j <= b.length; j++) {
+      const cost = a.charCodeAt(i - 1) === b.charCodeAt(j - 1) ? 0 : 1;
+      curr[j] = Math.min(prev[j] + 1, curr[j - 1] + 1, prev[j - 1] + cost);
+    }
+    [prev, curr] = [curr, prev];
+  }
+  return prev[b.length];
+}

--- a/src/app/features/home/home.html
+++ b/src/app/features/home/home.html
@@ -27,6 +27,10 @@
               {{ i18n.t('profile') }}
             </button>
             <button type="button" class="account-menu-item" role="menuitem"
+                    (click)="closeAccountMenu(); goSearch()">
+              {{ i18n.lang() === 'it' ? 'Cerca utenti' : 'Find users' }}
+            </button>
+            <button type="button" class="account-menu-item" role="menuitem"
                     (click)="closeAccountMenu(); goSettings()">
               {{ i18n.t('settings') }}
             </button>
@@ -39,6 +43,10 @@
             <button type="button" class="account-menu-item" role="menuitem"
                     (click)="closeAccountMenu(); goLogin()">
               {{ i18n.t('login') }}
+            </button>
+            <button type="button" class="account-menu-item" role="menuitem"
+                    (click)="closeAccountMenu(); goSearch()">
+              {{ i18n.lang() === 'it' ? 'Cerca utenti' : 'Find users' }}
             </button>
             <button type="button" class="account-menu-item" role="menuitem"
                     (click)="closeAccountMenu(); goSettings()">

--- a/src/app/features/home/home.ts
+++ b/src/app/features/home/home.ts
@@ -175,6 +175,10 @@ export class Home {
     this.router.navigate(['/feedback']);
   }
 
+  protected goSearch(): void {
+    this.router.navigate(['/search']);
+  }
+
   /** Toggle del popover account; chiude se aperto, apre se chiuso. Lo
    *  stopPropagation evita che il click-outside listener lo richiuda subito. */
   protected toggleAccountMenu(e: Event): void {

--- a/src/app/features/search/search.css
+++ b/src/app/features/search/search.css
@@ -1,0 +1,188 @@
+.search-page {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding-bottom: 32px;
+}
+
+/* Input con icona lente a sinistra e X a destra per pulire. */
+.search-input-wrap {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+.search-input-icon {
+  position: absolute;
+  left: 14px;
+  font-size: 18px;
+  color: var(--text-mute);
+  pointer-events: none;
+}
+.search-input {
+  width: 100%;
+  padding: 13px 44px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  color: var(--text);
+  font-size: 15px;
+  font-family: inherit;
+  outline: none;
+  box-sizing: border-box;
+  transition: border-color var(--hover-dur) ease;
+}
+.search-input:focus { border-color: var(--accent); }
+.search-input-clear {
+  position: absolute;
+  right: 10px;
+  appearance: none;
+  background: transparent;
+  border: 0;
+  color: var(--text-mute);
+  cursor: pointer;
+  width: 28px;
+  height: 28px;
+  display: grid;
+  place-items: center;
+  border-radius: 999px;
+  font-size: 12px;
+  transition: background var(--hover-dur) ease, color var(--hover-dur) ease;
+}
+.search-input-clear:hover {
+  background: var(--surface-2);
+  color: var(--text);
+}
+
+/* Spinner che appare al posto della X durante la ricerca. Cerchio ambra che
+   ruota su sfondo surface-2, dimensioni allineate al bottone X (28px). */
+.search-spinner {
+  position: absolute;
+  right: 14px;
+  width: 18px;
+  height: 18px;
+  border: 2px solid var(--surface-2);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: search-spin 0.7s linear infinite;
+}
+@keyframes search-spin {
+  to { transform: rotate(360deg); }
+}
+/* Con animazioni minimal disabilitiamo lo spin: lasciamo un cerchio statico
+   ambra per dare comunque feedback di attesa. */
+[data-motion="minimal"] .search-spinner {
+  animation: none;
+  border-top-color: var(--accent);
+  border-right-color: var(--accent);
+}
+
+/* Placeholder vuoto per evitare lo shift di layout quando i risultati
+   arrivano dopo che il loading se ne va. Stessa altezza dell'eyebrow header. */
+.search-loading-placeholder {
+  height: 24px;
+}
+
+/* Empty state: glifo grande accent + testo guida. Stile coerente col brand
+   (uso var(--font-glyph) per il glifo, stesso pattern di onboarding). */
+.search-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 12px;
+  padding: 40px 16px 24px;
+}
+.search-empty-glyph {
+  font-family: var(--font-glyph);
+  font-size: 56px;
+  color: var(--accent);
+  opacity: 0.5;
+  line-height: 1;
+}
+.search-empty-title {
+  margin: 0;
+}
+.search-empty p {
+  max-width: 320px;
+  font-size: 14px;
+  line-height: 1.5;
+  margin: 0;
+}
+
+.search-header {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  padding-top: 4px;
+}
+
+.search-results {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+/* Riga risultato: avatar circolare con iniziale + nickname + arrow. La
+   pillola "tu" appare se si trova il proprio profilo nella lista. */
+.search-result {
+  appearance: none;
+  display: grid;
+  grid-template-columns: 36px 1fr auto auto;
+  gap: 12px;
+  align-items: center;
+  width: 100%;
+  padding: 10px 14px 10px 10px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  cursor: pointer;
+  font: inherit;
+  color: var(--text);
+  text-align: left;
+  transition:
+    background var(--hover-dur) ease,
+    border-color var(--hover-dur) ease,
+    transform var(--hover-dur) ease;
+}
+.search-result:hover {
+  background: var(--surface-2);
+  border-color: var(--border-strong);
+  transform: translateY(-1px);
+}
+.search-result-avatar {
+  display: grid;
+  place-items: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: var(--accent);
+  color: var(--accent-contrast);
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 15px;
+  line-height: 1;
+}
+.search-result-nick {
+  font-size: 14px;
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.search-result-you {
+  font-size: 10px;
+  font-family: var(--font-mono);
+  letter-spacing: 0.04em;
+  color: var(--accent-contrast);
+  background: var(--accent);
+  padding: 2px 7px;
+  border-radius: 999px;
+  text-transform: uppercase;
+  font-weight: 600;
+  line-height: 1;
+}
+.search-result-arrow {
+  font-size: 18px;
+  color: var(--text-mute);
+  line-height: 1;
+}

--- a/src/app/features/search/search.html
+++ b/src/app/features/search/search.html
@@ -1,0 +1,88 @@
+<div class="app-shell">
+  <app-bar [canBack]="true"
+           [title]="i18n.lang() === 'it' ? 'Cerca utenti' : 'Find users'"
+           (back)="goBack()"
+           (goHome)="goHome()" />
+
+  <div class="page search-page">
+    <!-- Input ricerca: autofocus per digitare subito, X interna per pulire. -->
+    <div class="search-input-wrap">
+      <span class="search-input-icon" aria-hidden="true">⌕</span>
+      <input
+        type="text"
+        class="search-input"
+        autofocus
+        autocomplete="off"
+        autocapitalize="none"
+        spellcheck="false"
+        [placeholder]="i18n.lang() === 'it'
+          ? 'Cerca per nickname...'
+          : 'Search by nickname...'"
+        [ngModel]="query()"
+        (ngModelChange)="setQuery($event)"
+        (keydown.enter)="submitSearch()"
+      />
+      @if (loading()) {
+        <span class="search-spinner" aria-label="loading"></span>
+      } @else if (query()) {
+        <button class="search-input-clear" type="button" (click)="clearQuery()"
+                [attr.aria-label]="i18n.lang() === 'it' ? 'Cancella' : 'Clear'">
+          ✕
+        </button>
+      }
+    </div>
+
+    @if (loading()) {
+      <!-- Spinner gia' nell'input: qui solo placeholder vuoto per evitare
+           shift di layout mentre arriva il risultato. -->
+      <div class="search-loading-placeholder" aria-hidden="true"></div>
+    } @else if (!hasSearched()) {
+      @if (query().trim().length >= 1 && query().trim().length < 2) {
+        <p class="muted search-status">
+          {{ i18n.lang() === 'it'
+            ? 'Scrivi almeno 2 caratteri per cercare.'
+            : 'Type at least 2 characters to search.' }}
+        </p>
+      } @else {
+        <div class="search-empty">
+          <span class="search-empty-glyph" aria-hidden="true">字</span>
+          <p class="muted">
+            {{ i18n.lang() === 'it'
+              ? 'Scrivi un nickname per trovare altri giocatori e vedere i loro progressi.'
+              : 'Type a nickname to find other players and see their progress.' }}
+          </p>
+        </div>
+      }
+    } @else if (results().length === 0) {
+      <div class="search-empty">
+        <span class="search-empty-glyph" aria-hidden="true">∅</span>
+        <h3 class="h3 search-empty-title">
+          {{ i18n.lang() === 'it' ? 'Nessun risultato' : 'No results' }}
+        </h3>
+        <p class="muted">
+          @if (i18n.lang() === 'it') {
+            Niente di simile a <span class="mono">{{ query() }}</span>.
+          } @else {
+            Nothing close to <span class="mono">{{ query() }}</span>.
+          }
+        </p>
+      </div>
+    } @else {
+      <div class="search-header">
+        <span class="eyebrow">{{ resultsLabel() }}</span>
+      </div>
+      <div class="search-results">
+        @for (r of results(); track r.uid) {
+          <button class="search-result" type="button" (click)="openProfile(r.nick)">
+            <span class="search-result-avatar">{{ r.nick.charAt(0).toUpperCase() }}</span>
+            <span class="search-result-nick">{{ r.nick }}</span>
+            @if (r.uid === myUid()) {
+              <span class="search-result-you">{{ i18n.lang() === 'it' ? 'tu' : 'you' }}</span>
+            }
+            <span class="search-result-arrow" aria-hidden="true">›</span>
+          </button>
+        }
+      </div>
+    }
+  </div>
+</div>

--- a/src/app/features/search/search.ts
+++ b/src/app/features/search/search.ts
@@ -1,0 +1,93 @@
+import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
+import { Location } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { Router } from '@angular/router';
+import { I18nService } from '../../core/i18n/i18n.service';
+import { AppStateService } from '../../core/state/app-state.service';
+import { NicknameEntry, UserSearchService } from '../../core/firebase/user-search.service';
+import { AppBar } from '../../shared/app-bar';
+
+@Component({
+  selector: 'app-search',
+  imports: [AppBar, FormsModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './search.html',
+  styleUrl: './search.css',
+})
+export class Search {
+  private readonly router = inject(Router);
+  private readonly location = inject(Location);
+  protected readonly i18n = inject(I18nService);
+  private readonly appState = inject(AppStateService);
+  private readonly searchSvc = inject(UserSearchService);
+
+  protected readonly query = signal('');
+  protected readonly results = signal<NicknameEntry[]>([]);
+  protected readonly loading = signal(false);
+  protected readonly hasSearched = signal(false);
+
+  protected readonly myUid = computed(() => this.appState.state().account?.uid ?? null);
+
+  private debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  protected setQuery(v: string): void {
+    this.query.set(v);
+    if (this.debounceTimer) clearTimeout(this.debounceTimer);
+    // Debounce 250ms: l'utente che digita "alessio" non scatena 7 ricerche.
+    this.debounceTimer = setTimeout(() => void this.runSearch(), 250);
+  }
+
+  /** Trigger esplicito per la pressione Enter o il bottone "Cerca". */
+  protected submitSearch(): void {
+    if (this.debounceTimer) clearTimeout(this.debounceTimer);
+    void this.runSearch();
+  }
+
+  private async runSearch(): Promise<void> {
+    const q = this.query().trim();
+    if (q.length < 2) {
+      this.results.set([]);
+      this.hasSearched.set(false);
+      return;
+    }
+    this.loading.set(true);
+    try {
+      const r = await this.searchSvc.search(q);
+      this.results.set(r);
+      this.hasSearched.set(true);
+    } catch (e) {
+      console.warn('[search] error:', e);
+      this.results.set([]);
+      this.hasSearched.set(true);
+    } finally {
+      this.loading.set(false);
+    }
+  }
+
+  protected openProfile(nick: string): void {
+    this.router.navigate(['/u', nick]);
+  }
+
+  protected clearQuery(): void {
+    this.query.set('');
+    this.results.set([]);
+    this.hasSearched.set(false);
+  }
+
+  protected goBack(): void {
+    this.location.back();
+  }
+
+  protected goHome(): void {
+    this.router.navigate(['/home']);
+  }
+
+  /** Etichetta del conteggio con plurale corretto. */
+  protected resultsLabel(): string {
+    const n = this.results().length;
+    if (this.i18n.lang() === 'it') {
+      return n === 1 ? '1 utente trovato' : `${n} utenti trovati`;
+    }
+    return n === 1 ? '1 user found' : `${n} users found`;
+  }
+}


### PR DESCRIPTION
Nuova pagina di ricerca utenti, raggiungibile dal menu account in alto a destra della home (voce "Cerca utenti"). E' visibile sia agli utenti loggati che agli anonimi, perche' chiunque puo' guardare un profilo pubblico tramite il link /u/:nickname.

Flusso utente

Scrivi nel campo di ricerca un nickname: dopo 250ms di debounce parte la ricerca, durante la quale al posto della X di clear appare un piccolo spinner ambra che gira (statico ma colorato se hai motion=minimal). Risultati a tutta riga, ognuno con un cerchio ambra che mostra l'iniziale, il nickname, una eventuale pillola TU se sei tu stesso fra i risultati, e una freccia a destra. Click su una riga: navigazione a /u/{nickname} che e' la scheda pubblica gia' fatta.

Stati ben distinti: vuoto iniziale ("Scrivi un nickname...", glifo grande accent), input troppo corto ("Almeno 2 caratteri"), caricamento (spinner inline), nessun risultato (glifo nullset + messaggio in mono col tuo query), risultati ("X utenti trovati" come eyebrow).

Fuzzy matching

Tollerante fino a 2 errori di battitura. Ranking: match esatto > nickname che inizia con la query > nickname che contiene la query > Levenshtein distance 1 > Levenshtein distance 2. Tutto oltre 2 errori viene scartato. La fuzzy distance e' iterativa a due righe (memory-efficient anche per nick lunghi).

Tecnica e scalabilita'

Nuovo UserSearchService che carica la collezione /nicknames intera una sola volta a sessione (cache 5 minuti) e poi filtra/ordina lato client. Strategia volutamente semplice: ogni doc /nicknames pesa ~50 byte, leggere 100 utenti costa 5KB e 100 read Firestore (centesimi). Funziona benissimo fino a ~2000 utenti, oltre conviene un indice esterno (Algolia, Typesense) o uno schema n-gram in una collezione dedicata. Per ora overkill.

Usa firebase/firestore/lite come tutti gli altri service Firestore (no real-time, no offline persistence). Il bundle initial passa da 451kB a 466kB, sotto la soglia di warning 500kB.

Cosa NON in questa PR

Filtro per stats (es. "cerca utenti con accuracy > 80%"). Servirebbe leggere /users di ogni risultato e filtrare, costo molto piu' alto e UX non chiara. Lasciato fuori.

Ricerca per parte di display name (es. "Alessio Pes" mentre il nickname e' "alessio.pes2"). I display name non vivono in /nicknames, solo in /users.{nickname}. Per ora basta cercare per nickname; quando avremo display name separati e validati lo aggiungiamo.

Cache invalidation in tempo reale: se un altro utente si registra mentre tu hai la pagina /cerca aperta, lo vedrai solo dopo che il TTL della cache (5 min) scade. C'e' anche un metodo invalidateCache() pubblico se in futuro serve forzare.