### PR TITLE
feat(leaderboard): pagina classifica con tab Daily / Tutti i tempi

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,7 @@ src/
       game/
       glyph-detail/
       home/
+      leaderboard/
       login/
       onboarding/
       profile/
@@ -301,6 +302,7 @@ L'app si appoggia a Firebase Auth + Firestore per login e sincronizzazione del p
 - `src/app/core/firebase/user-doc.service.ts`: `UserDocService` che sincronizza lo stato di gioco con `/users/{uid}` su Firestore quando l'utente e' loggato. Bootstrap-attivato (inject dummy in `App`). All'auth.user che diventa autenticato fa max-merge tra locale e cloud; al primo signup chiama `NicknameService.findAvailable` per claimare un nickname unico. Ad ogni cambio di state mentre loggato, push debounced di 1s. Usa `firebase/firestore/lite` (no real-time, no offline persistence) per tenere il bundle sotto i 500kB.
 - `src/app/core/firebase/nickname.service.ts`: `NicknameService` gestisce la collezione `/nicknames/{nick_lowercased}` per garantire l'unicita' del nickname. Metodi: `claim(nick, uid)` atomica via runTransaction, `change(oldNick, newNick, uid)` swap atomico (release vecchio + claim nuovo + update `/users/{uid}.nickname` in una sola transazione), `findAvailable(seed, uid)` cerca varianti seed/seed2/seed3/.../seed-rnd, `getUserByNickname(nick)` per il profilo pubblico.
 - `src/app/core/firebase/user-search.service.ts`: `UserSearchService` cerca utenti per nickname con tolleranza fuzzy (Levenshtein <=2). Carica la collezione `/nicknames` intera in cache (TTL 5 min) e fa filtering/ranking client-side: match esatto > prefisso > sottostringa > distanza 1 > distanza 2. Strategia OK fino a ~2000 utenti; oltre, conviene un indice esterno tipo Algolia.
+- `src/app/core/firebase/leaderboard.service.ts`: `LeaderboardService` legge la classifica da `/users`. Due viste: `daily` (filtra per `dailyDoneStamp == today`, sort `dailyScore` desc) e `alltime` (sort `correctAnswers` desc). Paginazione cursor-based via `startAfter`, page size 30. Niente cache: ogni cambio tab e ogni "Mostra altri" e' una fetch fresca.
 - `AppStateService` si abbona al signal `auth.user` via `effect`: a ogni cambio di stato Auth, riflette in `state.account` (uid, email, nickname seedato da `displayName` per Google, avatar 0 di default).
 - `firestore.rules`, `firebase.json`, `.firebaserc` alla root: config per `firebase deploy`. Schema corrente: `/users/{uid}` (stato gioco + anagrafica) e `/nicknames/{nick}` (indice unicita', non ancora popolato).
 
@@ -322,7 +324,7 @@ Le scritture successive durante la sessione fanno **full overwrite** del documen
 
 ### Cosa NON e' ancora collegato
 
-- La route `/leaderboard` e' ancora `ComingSoon`. La PR che la accendera' usera' gia' lo stato Auth (`AuthService.user()`) come fonte di verita' e i progressi cloud da `/users/{uid}`.
+- `/leaderboard` reale: due tab Daily / Alltime. Daily sort per `dailyScore`, filtra solo chi ha completato la sfida di oggi. Alltime sort per `correctAnswers`. Top 3 con medaglie 🥇🥈🥉, evidenza ambra sulla propria riga, click su un'altra riga porta a `/u/:nickname`. Paginazione "Mostra altri" 30 alla volta. Weekly/Monthly non implementati: per averli onestamente servirebbe tracciare contatori a finestra temporale (incremento per ogni partita + reset al cambio settimana/mese). Per ora fuori scope.
 - `/profile` reale: hero con avatar editabile in modale (12 glifi predefiniti in `AVATARS`), nickname inline edit (Enter salva, Esc annulla, errore "gia' preso" via transazione `NicknameService.change`), stats 2x2, lista per-scrittura con barre colorate (verde >=75%, ambra >=40%, rosso <40%), badges teaser, storico daily.
 - `/u/:nickname` profilo pubblico reale: pillola "TU" accanto al nome se sei tu, avatar 96px, "Membro da MMMM YYYY", stats 2x2 (best, accuracy, played, dailyStreak), lista per-scrittura con barre colorate, griglia 4-col dei badge sbloccati. CTA in fondo cambia in base a "tu / altri": se sei tu mostra "Condividi profilo", altrimenti "Vuoi battere X? Gioca anche tu". Read pubblica via `NicknameService.getUserByNickname`.
 - `/search` ricerca utenti: input con debounce 250ms, fuzzy fino a 2 errori, "X utenti trovati", risultati cliccabili che portano a `/u/:nickname`. Accessibile dal menu account della home, voce "Cerca utenti".

--- a/firebase.json
+++ b/firebase.json
@@ -1,5 +1,6 @@
 {
   "firestore": {
-    "rules": "firestore.rules"
+    "rules": "firestore.rules",
+    "indexes": "firestore.indexes.json"
   }
 }

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,13 @@
+{
+  "indexes": [
+    {
+      "collectionGroup": "users",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "dailyDoneStamp", "order": "ASCENDING" },
+        { "fieldPath": "dailyScore", "order": "DESCENDING" }
+      ]
+    }
+  ],
+  "fieldOverrides": []
+}

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
     "deploy:rules": "npx firebase deploy --only firestore:rules",
+    "deploy:indexes": "npx firebase deploy --only firestore:indexes",
+    "deploy:firestore": "npx firebase deploy --only firestore",
     "prestart": "node scripts/write-build-sha.mjs",
     "prebuild": "node scripts/write-build-sha.mjs",
     "postinstall": "node scripts/write-build-sha.mjs"

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -84,8 +84,11 @@ export const routes: Routes = [
     loadComponent: () => import('./features/search/search').then((m) => m.Search),
   },
 
-  // Aree social ancora stub: classifica, sfide tra amici.
-  { path: 'leaderboard',       canActivate: [onboardedGuard], loadComponent: comingSoon },
+  {
+    path: 'leaderboard',
+    canActivate: [onboardedGuard],
+    loadComponent: () => import('./features/leaderboard/leaderboard').then((m) => m.Leaderboard),
+  },
 
   // Profilo pubblico di un utente qualunque. NO onboardedGuard: deve essere
   // raggiungibile anche da link condiviso fuori dall'app prima di essere

--- a/src/app/core/firebase/leaderboard.service.ts
+++ b/src/app/core/firebase/leaderboard.service.ts
@@ -1,0 +1,93 @@
+import { Injectable } from '@angular/core';
+import {
+  Firestore,
+  QueryDocumentSnapshot,
+  collection,
+  getDocs,
+  getFirestore,
+  limit,
+  orderBy,
+  query,
+  startAfter,
+  where,
+} from 'firebase/firestore/lite';
+import { ensureFirebaseApp } from './firebase';
+
+export type LeaderboardPeriod = 'daily' | 'alltime';
+
+export interface LeaderboardRow {
+  uid: string;
+  nickname: string;
+  avatar: number;
+  /** Score visualizzato sulla destra. Su Daily = dailyScore (0-5), su Alltime
+   *  = correctAnswers (intero non negativo). */
+  score: number;
+}
+
+/**
+ * Classifica letta dalla collezione `/users`. Due viste:
+ *  - daily: filtra per dailyDoneStamp == oggi, sort per dailyScore desc
+ *  - alltime: sort per correctAnswers desc
+ *
+ * Paginazione cursor-based via `startAfter`: la prima fetch carica i primi N
+ * documenti, le successive partono dall'ultimo doc della pagina precedente.
+ * Niente caching: ogni cambio di tab e ogni "Mostra altri" e' una fetch fresca.
+ */
+@Injectable({ providedIn: 'root' })
+export class LeaderboardService {
+  private readonly db: Firestore | null;
+
+  constructor() {
+    const app = ensureFirebaseApp();
+    this.db = app ? getFirestore(app) : null;
+  }
+
+  /** Fetch della pagina iniziale (o successiva tramite `after`). */
+  async fetch(
+    period: LeaderboardPeriod,
+    pageSize: number,
+    after?: QueryDocumentSnapshot | null,
+  ): Promise<LeaderboardPage> {
+    if (!this.db) return { rows: [], lastDoc: null, hasMore: false };
+    const usersRef = collection(this.db, 'users');
+    const constraints =
+      period === 'daily'
+        ? [
+            where('dailyDoneStamp', '==', new Date().toDateString()),
+            orderBy('dailyScore', 'desc'),
+          ]
+        : [orderBy('correctAnswers', 'desc')];
+    const q = after
+      ? query(usersRef, ...constraints, startAfter(after), limit(pageSize))
+      : query(usersRef, ...constraints, limit(pageSize));
+    const snap = await getDocs(q);
+    const rows: LeaderboardRow[] = [];
+    snap.forEach((d) => {
+      const data = d.data() as Record<string, unknown>;
+      rows.push({
+        uid: d.id,
+        nickname: typeof data['nickname'] === 'string' ? (data['nickname'] as string) : '',
+        avatar: typeof data['avatar'] === 'number' ? (data['avatar'] as number) : 0,
+        score:
+          period === 'daily'
+            ? typeof data['dailyScore'] === 'number'
+              ? (data['dailyScore'] as number)
+              : 0
+            : typeof data['correctAnswers'] === 'number'
+              ? (data['correctAnswers'] as number)
+              : 0,
+      });
+    });
+    const lastDoc = snap.docs.length > 0 ? snap.docs[snap.docs.length - 1] : null;
+    // hasMore approssimato: se ho ricevuto `pageSize` righe, probabilmente c'e'
+    // ancora qualcosa dopo. Un'altra fetch potrebbe tornare vuota: la UI lo
+    // gestisce graziosamente (Mostra altri sparisce dopo la prima pagina vuota).
+    return { rows, lastDoc, hasMore: rows.length === pageSize };
+  }
+}
+
+export interface LeaderboardPage {
+  rows: LeaderboardRow[];
+  lastDoc: QueryDocumentSnapshot | null;
+  hasMore: boolean;
+}

--- a/src/app/features/leaderboard/leaderboard.css
+++ b/src/app/features/leaderboard/leaderboard.css
@@ -1,0 +1,247 @@
+.lb-page {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding-bottom: 32px;
+}
+
+/* Tab switch Daily/Alltime: stile pillola (riusa idea di .lb-tabs del mockup
+   ma scoped qui perche' non ha altri usi nel resto dell'app). */
+.lb-tabs {
+  display: flex;
+  gap: 4px;
+  padding: 4px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  margin-top: 4px;
+}
+.lb-tab {
+  appearance: none;
+  flex: 1;
+  height: 36px;
+  border: 0;
+  border-radius: 9px;
+  background: transparent;
+  color: var(--text-dim);
+  font: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition:
+    background var(--hover-dur) ease,
+    color var(--hover-dur) ease;
+}
+.lb-tab:hover:not(.is-active) {
+  background: var(--surface-2);
+}
+.lb-tab.is-active {
+  background: var(--surface-3);
+  color: var(--text);
+}
+
+/* Card "Accedi per comparire in classifica" visibile solo se anonimo. */
+.lb-signin-card {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px;
+}
+.lb-signin-text {
+  flex: 1;
+  font-size: 13px;
+  color: var(--text-dim);
+}
+.lb-signin-btn {
+  height: 36px;
+  font-size: 13px;
+  padding: 0 14px;
+}
+
+/* Header colonna sulla tabella della classifica: piccoli eyebrow grigi. */
+.lb-head {
+  display: grid;
+  grid-template-columns: 40px 1fr 80px;
+  gap: 8px;
+  padding: 14px 12px 8px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-mute);
+}
+.lb-head-rank { text-align: right; }
+.lb-head-score { text-align: right; }
+
+.lb-loading {
+  display: flex;
+  justify-content: center;
+  padding: 32px 0;
+}
+
+/* Spinner ambra. Stessa estetica usata in /cerca, ma piu' grande qui. */
+.lb-spinner {
+  width: 24px;
+  height: 24px;
+  border: 2px solid var(--surface-2);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: lb-spin 0.7s linear infinite;
+}
+.lb-spinner-inline {
+  width: 16px;
+  height: 16px;
+  display: inline-block;
+}
+@keyframes lb-spin {
+  to { transform: rotate(360deg); }
+}
+[data-motion="minimal"] .lb-spinner {
+  animation: none;
+}
+
+.lb-error {
+  text-align: center;
+  padding: 24px 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+}
+.lb-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 12px;
+  padding: 40px 16px 24px;
+}
+.lb-empty-glyph {
+  font-family: var(--font-glyph);
+  font-size: 56px;
+  color: var(--accent);
+  opacity: 0.5;
+  line-height: 1;
+}
+.lb-empty p {
+  max-width: 320px;
+  font-size: 14px;
+  line-height: 1.5;
+  margin: 0;
+}
+
+.lb-rows {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+/* Riga della classifica: rank | (avatar + nick + pillola TU) | score.
+   Highlight ambra quando e' la riga dell'utente loggato (is-self). */
+.lb-row {
+  appearance: none;
+  display: grid;
+  grid-template-columns: 40px 1fr 80px;
+  gap: 8px;
+  align-items: center;
+  width: 100%;
+  padding: 10px 12px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  cursor: pointer;
+  font: inherit;
+  color: var(--text);
+  text-align: left;
+  transition:
+    background var(--hover-dur) ease,
+    border-color var(--hover-dur) ease;
+}
+.lb-row:hover {
+  background: var(--surface-2);
+  border-color: var(--border-strong);
+}
+.lb-row.is-self {
+  background: rgba(251, 191, 36, 0.08);
+  border-color: rgba(251, 191, 36, 0.35);
+}
+
+.lb-row-rank {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  font-size: 14px;
+  color: var(--text-dim);
+}
+.lb-row.is-self .lb-row-rank {
+  color: var(--warm);
+  font-weight: 600;
+}
+.lb-row-medal {
+  font-size: 18px;
+  line-height: 1;
+}
+
+.lb-row-player {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+.lb-row-avatar {
+  flex-shrink: 0;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: var(--surface-2);
+  color: var(--text);
+  border: 1.5px solid var(--border);
+  display: grid;
+  place-items: center;
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 13px;
+  line-height: 1;
+}
+.lb-row-avatar.accent {
+  background: var(--accent);
+  color: var(--accent-contrast);
+  border-color: transparent;
+}
+.lb-row-nick {
+  font-size: 14px;
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+  min-width: 0;
+}
+.lb-row.is-self .lb-row-nick {
+  font-weight: 600;
+}
+.lb-row-you {
+  font-size: 10px;
+  font-family: var(--font-mono);
+  letter-spacing: 0.04em;
+  color: var(--accent-contrast);
+  background: var(--accent);
+  padding: 2px 7px;
+  border-radius: 999px;
+  text-transform: uppercase;
+  font-weight: 600;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.lb-row-score {
+  text-align: right;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+.lb-row.is-self .lb-row-score {
+  color: var(--warm);
+}
+
+.lb-more {
+  margin-top: 12px;
+}

--- a/src/app/features/leaderboard/leaderboard.html
+++ b/src/app/features/leaderboard/leaderboard.html
@@ -1,0 +1,114 @@
+<div class="app-shell">
+  <app-bar [canBack]="true"
+           [title]="i18n.t('leaderboard')"
+           (back)="goBack()"
+           (goHome)="goHome()" />
+
+  <div class="page lb-page">
+    <!-- Tab switch: solo Daily e Alltime per ora. Weekly/Monthly verra' quando
+         tracceremo i contatori a finestra temporale. -->
+    <div class="lb-tabs">
+      <button class="lb-tab" type="button"
+              [class.is-active]="period() === 'daily'"
+              (click)="setPeriod('daily')">
+        {{ i18n.lang() === 'it' ? 'Giornaliera' : 'Daily' }}
+      </button>
+      <button class="lb-tab" type="button"
+              [class.is-active]="period() === 'alltime'"
+              (click)="setPeriod('alltime')">
+        {{ i18n.lang() === 'it' ? 'Tutti i tempi' : 'All time' }}
+      </button>
+    </div>
+
+    @if (!appState.state().account) {
+      <div class="card lb-signin-card">
+        <div class="lb-signin-text">
+          {{ i18n.lang() === 'it'
+            ? 'Accedi per comparire in classifica.'
+            : 'Sign in to appear on the leaderboard.' }}
+        </div>
+        <button class="btn btn-primary lb-signin-btn" type="button" (click)="goLogin()">
+          {{ i18n.t('login') }}
+        </button>
+      </div>
+    }
+
+    <div class="lb-head">
+      <span class="lb-head-rank">#</span>
+      <span class="lb-head-player">
+        {{ i18n.lang() === 'it' ? 'Giocatore' : 'Player' }}
+      </span>
+      <span class="lb-head-score">
+        {{ i18n.lang() === 'it' ? 'Punti' : 'Score' }}
+      </span>
+    </div>
+
+    @if (loading()) {
+      <div class="lb-loading">
+        <span class="lb-spinner" aria-label="loading"></span>
+      </div>
+    } @else if (error(); as e) {
+      <div class="lb-error">
+        <p class="muted">{{ e }}</p>
+        <button class="btn btn-ghost" type="button" (click)="retry()">
+          {{ i18n.lang() === 'it' ? 'Riprova' : 'Retry' }}
+        </button>
+      </div>
+    } @else if (rows().length === 0) {
+      <div class="lb-empty">
+        <span class="lb-empty-glyph" aria-hidden="true">∅</span>
+        <p class="muted">
+          @if (period() === 'daily') {
+            {{ i18n.lang() === 'it'
+              ? 'Nessuno ha ancora completato la sfida di oggi. Sii il primo!'
+              : 'No one has completed today\'s challenge yet. Be the first!' }}
+          } @else {
+            {{ i18n.lang() === 'it'
+              ? 'Nessuna classifica ancora. I primi giocatori la stanno costruendo.'
+              : 'No leaderboard yet. The first players are building it.' }}
+          }
+        </p>
+      </div>
+    } @else {
+      <div class="lb-rows">
+        @for (r of rows(); track r.uid; let i = $index) {
+          <button class="lb-row"
+                  [class.is-self]="r.uid === myUid()"
+                  type="button"
+                  (click)="openProfile(r.nickname)">
+            <span class="lb-row-rank">
+              @if (medal(i + 1); as m) {
+                <span class="lb-row-medal">{{ m }}</span>
+              } @else {
+                {{ i + 1 }}
+              }
+            </span>
+            <span class="lb-row-player">
+              <span class="lb-row-avatar" [class.accent]="r.uid === myUid()">
+                {{ (r.nickname || '?').charAt(0).toUpperCase() }}
+              </span>
+              <span class="lb-row-nick">{{ r.nickname }}</span>
+              @if (r.uid === myUid()) {
+                <span class="lb-row-you">{{ i18n.lang() === 'it' ? 'tu' : 'you' }}</span>
+              }
+            </span>
+            <span class="lb-row-score mono">{{ formatScore(r.score, period()) }}</span>
+          </button>
+        }
+      </div>
+
+      @if (hasMore()) {
+        <button class="btn btn-ghost btn-block lb-more"
+                type="button"
+                [disabled]="loadingMore()"
+                (click)="loadMore()">
+          @if (loadingMore()) {
+            <span class="lb-spinner lb-spinner-inline" aria-label="loading"></span>
+          } @else {
+            {{ i18n.lang() === 'it' ? 'Mostra altri' : 'Show more' }}
+          }
+        </button>
+      }
+    }
+  </div>
+</div>

--- a/src/app/features/leaderboard/leaderboard.ts
+++ b/src/app/features/leaderboard/leaderboard.ts
@@ -1,0 +1,138 @@
+import { ChangeDetectionStrategy, Component, computed, effect, inject, signal } from '@angular/core';
+import { Location } from '@angular/common';
+import { Router } from '@angular/router';
+import { I18nService } from '../../core/i18n/i18n.service';
+import { AppStateService } from '../../core/state/app-state.service';
+import {
+  LeaderboardPeriod,
+  LeaderboardRow,
+  LeaderboardService,
+} from '../../core/firebase/leaderboard.service';
+import { AppBar } from '../../shared/app-bar';
+
+/**
+ * Pagina classifica con due viste (Daily/Alltime) e paginazione "Mostra
+ * altri". Le righe sono cliccabili e portano al profilo pubblico
+ * dell'utente. Top 3 hanno medaglie 🥇🥈🥉. La riga corrente (l'utente
+ * loggato) e' evidenziata in ambra con pillola "TU".
+ */
+@Component({
+  selector: 'app-leaderboard',
+  imports: [AppBar],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './leaderboard.html',
+  styleUrl: './leaderboard.css',
+})
+export class Leaderboard {
+  private readonly router = inject(Router);
+  private readonly location = inject(Location);
+  protected readonly i18n = inject(I18nService);
+  protected readonly appState = inject(AppStateService);
+  private readonly lbSvc = inject(LeaderboardService);
+
+  protected readonly period = signal<LeaderboardPeriod>('alltime');
+  protected readonly rows = signal<LeaderboardRow[]>([]);
+  protected readonly loading = signal(false);
+  protected readonly loadingMore = signal(false);
+  protected readonly hasMore = signal(false);
+  /** Errore generico (rete, rules, ecc.). Se settato, la UI mostra un retry. */
+  protected readonly error = signal<string | null>(null);
+
+  /** Cursor della paginazione: ultimo doc snapshot della pagina corrente. */
+  private lastDoc: Awaited<ReturnType<LeaderboardService['fetch']>>['lastDoc'] = null;
+
+  private readonly PAGE_SIZE = 30;
+
+  protected readonly myUid = computed(() => this.appState.state().account?.uid ?? null);
+
+  constructor() {
+    // Carica la prima pagina quando cambia il period.
+    effect(() => {
+      const p = this.period();
+      void this.firstLoad(p);
+    });
+  }
+
+  protected setPeriod(p: LeaderboardPeriod): void {
+    if (this.period() === p) return;
+    this.period.set(p);
+  }
+
+  private async firstLoad(period: LeaderboardPeriod): Promise<void> {
+    this.loading.set(true);
+    this.error.set(null);
+    this.rows.set([]);
+    this.lastDoc = null;
+    try {
+      const page = await this.lbSvc.fetch(period, this.PAGE_SIZE);
+      this.rows.set(page.rows);
+      this.lastDoc = page.lastDoc;
+      this.hasMore.set(page.hasMore);
+    } catch (e) {
+      console.warn('[leaderboard] error:', e);
+      this.error.set(this.translateError(e));
+    } finally {
+      this.loading.set(false);
+    }
+  }
+
+  protected async loadMore(): Promise<void> {
+    if (this.loadingMore() || !this.hasMore() || !this.lastDoc) return;
+    this.loadingMore.set(true);
+    try {
+      const page = await this.lbSvc.fetch(this.period(), this.PAGE_SIZE, this.lastDoc);
+      this.rows.update((rs) => [...rs, ...page.rows]);
+      this.lastDoc = page.lastDoc;
+      this.hasMore.set(page.hasMore);
+    } catch (e) {
+      console.warn('[leaderboard] loadMore error:', e);
+      this.error.set(this.translateError(e));
+    } finally {
+      this.loadingMore.set(false);
+    }
+  }
+
+  protected openProfile(nick: string): void {
+    if (!nick) return;
+    this.router.navigate(['/u', nick]);
+  }
+
+  protected medal(rank: number): string {
+    if (rank === 1) return '🥇';
+    if (rank === 2) return '🥈';
+    if (rank === 3) return '🥉';
+    return '';
+  }
+
+  /** Formatta score per il display: Daily mostra "N/5", Alltime numero plain. */
+  protected formatScore(score: number, period: LeaderboardPeriod): string {
+    if (period === 'daily') return `${score}/5`;
+    return score.toLocaleString(this.i18n.lang() === 'it' ? 'it-IT' : 'en-GB');
+  }
+
+  protected goBack(): void {
+    this.location.back();
+  }
+  protected goHome(): void {
+    this.router.navigate(['/home']);
+  }
+  protected goLogin(): void {
+    this.router.navigate(['/login']);
+  }
+  protected retry(): void {
+    void this.firstLoad(this.period());
+  }
+
+  private translateError(e: unknown): string {
+    const code = (e as { code?: string })?.code ?? '';
+    const isIt = this.i18n.lang() === 'it';
+    if (code === 'failed-precondition' || (e as Error)?.message?.includes('index')) {
+      return isIt
+        ? 'Indice Firestore mancante. Esegui "npm run deploy:indexes" per crearlo.'
+        : 'Missing Firestore index. Run "npm run deploy:indexes" to create it.';
+    }
+    return isIt
+      ? 'Qualcosa non ha funzionato. Riprova tra poco.'
+      : 'Something went wrong. Please try again.';
+  }
+}


### PR DESCRIPTION
Sostituisce il placeholder /leaderboard con la pagina vera. Due tab, dati reali da Firestore, righe cliccabili che vanno al profilo pubblico dell'utente, paginazione.

Funzionamento

Tab Giornaliera: query a /users con where(dailyDoneStamp, ==, today) + orderBy(dailyScore, desc). Mostra solo i giocatori che hanno completato la sfida di oggi, ordinati per punteggio. Score visualizzato come "N/5".

Tab Tutti i tempi: query a /users con orderBy(correctAnswers, desc). Ranking generale per risposte corrette totali. Score visualizzato come numero plain con formatter locale.

I primi tre rank in entrambe le tab hanno medaglie 🥇🥈🥉 al posto del numero. La tua riga (utente loggato) e' in highlight ambra con la pillola TU accanto al nickname. Click su una qualunque riga apre /u/{nickname}, chiudendo il cerchio con il profilo pubblico aggiunto in #51.

Card "Accedi per comparire in classifica" visibile in cima quando sei anonimo. Empty state se la collezione e' vuota (con messaggio diverso per Daily vs Alltime).

Paginazione

Cursor-based via startAfter(lastDoc), page size 30. Bottone "Mostra altri" in fondo che aggiunge i prossimi 30, finche' la pagina ritorna meno righe del limite. Niente infinite scroll: tap esplicito per chiarezza e per non bruciare reads.

Setup richiesto una-tantum

La query Daily ha bisogno di un indice composito su (dailyDoneStamp ASC, dailyScore DESC). L'ho aggiunto a firestore.indexes.json e c'e' un nuovo script npm run deploy:indexes per pushare. Senza l'indice, la query Daily fallisce con failed-precondition e il componente mostra un errore traducibile che suggerisce esattamente quel comando.

Cose NON in questa PR

Tab Weekly e Monthly. Per farle in modo onesto servirebbe tracciare contatori a finestra temporale (incrementare per ogni partita giocata e azzerare al cambio settimana/mese). Aggiungero' quando ne avro' voglia (e' ~80 righe in piu' nello stato + UserDocService che gestisce il rollover).

Rank dell'utente quando e' oltre la top 30. Si potrebbe fare con un getCountFromServer (where('correctAnswers', '>', myScore)) ma per ora non lo fa. La pillola TU appare solo se sei nelle pagine caricate.

Tecnica

Nuovo LeaderboardService in core/firebase/ usa firebase/firestore/lite. Niente caching: ogni cambio tab e ogni "Mostra altri" e' una fetch fresca (i risultati cambiano in tempo reale via sync da UserDocService, gli stale data sarebbero confusi).

Bundle initial passa da 466KB a 469KB.