### PR TITLE
fix(quiz,script-detail): opzioni dalla pool selezionata + griglia caratteri responsive

### DIFF
--- a/src/app/core/data/quiz.ts
+++ b/src/app/core/data/quiz.ts
@@ -33,15 +33,23 @@ export function seedFromDate(d: Date = new Date()): number {
 }
 
 /**
- * Build a quiz question. `selectedIds` is the pool the correct answer is drawn
- * from; distractors prefer the same pool but fall back to the full catalog.
- * `prevId` is avoided as the correct answer when possible (no two in a row).
+ * Build a quiz question. `selectedIds` e' il pool da cui peschiamo SIA la
+ * risposta corretta SIA i distrattori: niente fallback ai SCRIPTS globali se
+ * il pool e' piccolo. Cosi' se hai selezionato 2 sole scritture, vedi 2 sole
+ * opzioni; se 3, ne vedi 3; se 4+, sempre 4 (cap massimo). L'idea: il quiz
+ * non deve mai mostrare scritture che l'utente ha esplicitamente escluso.
+ *
+ * `prevId` viene evitato come risposta corretta quando possibile, per non
+ * mostrare due domande di fila sulla stessa scrittura.
  */
 export function buildQuestion(
   rng: Rng,
   selectedIds: ReadonlyArray<string>,
   prevId: string | null,
 ): Question {
+  // Safety net: se il pool e' degenerato (0 o 1 scrittura) cadiamo sul
+  // catalogo completo, altrimenti non c'e' una domanda da costruire. UI dovrebbe
+  // impedirlo con la regola "almeno 2 scritture" sulla selezione.
   let pool = selectedIds.slice();
   if (pool.length < 2) {
     pool = SCRIPTS.map((s) => s.id);
@@ -59,19 +67,14 @@ export function buildQuestion(
   }
   const glyph = correct.samples[Math.floor(rng() * correct.samples.length)];
 
+  // Distrattori: massimo 3, solo dalla stessa pool selezionata. Se la pool ha
+  // 2 scritture, distrattori = 1; se 3, distrattori = 2; se 4+, distrattori = 3.
   const others = pool.filter((id) => id !== correctId);
   const shuffled = others.slice().sort(() => rng() - 0.5);
   const distractors: ScriptInfo[] = shuffled
     .slice(0, 3)
     .map((id) => scriptById(id))
     .filter((s): s is ScriptInfo => !!s);
-
-  while (distractors.length < 3) {
-    const candidate = SCRIPTS[Math.floor(rng() * SCRIPTS.length)];
-    if (candidate.id !== correctId && !distractors.find((d) => d.id === candidate.id)) {
-      distractors.push(candidate);
-    }
-  }
 
   const options = [correct, ...distractors].sort(() => rng() - 0.5);
   const cp = (glyph.codePointAt(0) ?? 0).toString(16).toUpperCase().padStart(4, '0');

--- a/src/app/features/game/game.html
+++ b/src/app/features/game/game.html
@@ -60,13 +60,17 @@
           }
         }
       </span>
-      <button
-        class="hint-btn"
-        type="button"
-        [disabled]="chosen() !== null || hintsLeft() <= 0"
-        (click)="useHint()"
-        aria-label="Use hint"
-      >💡<span class="mono tabnum hint-count">{{ hintsLeft() }}</span></button>
+      @if ((question()?.options?.length ?? 0) >= 3) {
+        <!-- Nascosto se opzioni < 3: l'hint nasconde 1 distrattore, e con sole
+             2 opzioni rivelerebbe la risposta (inutile). -->
+        <button
+          class="hint-btn"
+          type="button"
+          [disabled]="chosen() !== null || hintsLeft() <= 0"
+          (click)="useHint()"
+          aria-label="Use hint"
+        >💡<span class="mono tabnum hint-count">{{ hintsLeft() }}</span></button>
+      }
     </div>
 
     @if (question(); as q) {

--- a/src/app/features/game/game.ts
+++ b/src/app/features/game/game.ts
@@ -206,7 +206,11 @@ export class Game implements OnDestroy {
     if (!q) return;
     this.sound.playTick();
     const wrongs = q.options.filter((o) => o.id !== q.correct.id).map((o) => o.id);
-    const elim = wrongs.sort(() => 0.5 - Math.random()).slice(0, 2);
+    // Quanti distrattori togliere: al massimo 2 (comportamento storico con 4
+    // opzioni), ma sempre lasciandone almeno uno visibile oltre alla corretta.
+    // Cosi' con 3 opzioni totali (2 distrattori) ne togliamo 1, non 2.
+    const toRemove = Math.min(2, Math.max(0, wrongs.length - 1));
+    const elim = wrongs.sort(() => 0.5 - Math.random()).slice(0, toRemove);
     this.eliminated.set(elim);
     this.hintsLeft.update((n) => n - 1);
   }

--- a/src/app/features/script-detail/script-detail.css
+++ b/src/app/features/script-detail/script-detail.css
@@ -62,10 +62,15 @@
   margin-bottom: 8px;
 }
 
+/* Griglia auto-fill cosi' il numero di colonne si adatta alla larghezza
+   disponibile e i glifi vanno a capo invece di sforare a destra. min-width:0
+   sul container e' la cintura: rompe il comportamento default min-content
+   dei flex/grid children che impediva il wrap. */
 .sd-grid {
   display: grid;
-  grid-template-columns: repeat(8, 1fr);
+  grid-template-columns: repeat(auto-fill, minmax(40px, 1fr));
   gap: 6px;
+  min-width: 0;
 }
 
 .sd-cell {


### PR DESCRIPTION
Due fix indipendenti raccolti insieme perche' piccoli.

Quiz con selezione ridotta

Prima buildQuestion forzava sempre 4 opzioni: se la pool selezionata ne aveva meno di 4 distrattori disponibili, riempiva fino a 4 pescando dal catalogo SCRIPTS completo. Risultato: se selezionavi solo Hiragana + Katakana per il quiz, vedevi comparire Hindi o Arabo come distrattori, scritture che avevi esplicitamente escluso.

Ora i distrattori restano nella pool. Se selezioni 2 scritture vedi 2 opzioni (1 corretta + 1 distrattore), se ne selezioni 3 vedi 3 opzioni, da 4 in su sempre 4 opzioni cap.

L'hint si adatta:
- 4 opzioni: toglie 2 distrattori (lascia 1 distrattore + corretta = 2 visibili)
- 3 opzioni: toglie 1 distrattore (lascia 1 + corretta = 2 visibili)
- 2 opzioni: il bottone hint non viene proprio mostrato. Toglierne uno rivelerebbe la risposta, l'hint sarebbe un cheat completo.

La logica useHint() ora clamp toRemove a min(2, wrongs.length - 1), garantendo che resti sempre almeno un distrattore visibile insieme alla corretta.

Per la sfida giornaliera nulla cambia: lavora sempre su ALL_SCRIPT_IDS (catalogo completo), quindi 4 opzioni sempre.

Script detail: griglia caratteri overflow

Su /script/arabic (e potenzialmente altre scritture con glifi un po' piu' larghi) la griglia "Caratteri di esempio" continuava a destra oltre il bordo del telefono invece di andare a capo. Causa: grid-template-columns: repeat(8, 1fr) era una griglia a 8 colonne fisse, e i glifi che intrinsecamente eccedevano 1/8 della container width espandevano le colonne oltre il limite.

Cambiata in repeat(auto-fill, minmax(40px, 1fr)): il numero di colonne si adatta alla larghezza disponibile (10 colonne su desktop, 7 su mobile), e ogni cella ha una larghezza minima garantita di 40px. Aggiunto anche min-width: 0 sul container per neutralizzare il default min-content auto dei flex children.