### PR TITLE
feat(feedback): pagina feedback con Firestore + rate limit 3/giorno

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,7 @@ src/
     features/               # una cartella per ogni schermata
       badges/
       daily-result/
+      feedback/
       game/
       glyph-detail/
       home/
@@ -301,8 +302,9 @@ L'app si appoggia a Firebase Auth + Firestore per login e sincronizzazione del p
 - `src/app/core/firebase/user-doc.service.ts`: `UserDocService` che sincronizza lo stato di gioco con `/users/{uid}` su Firestore quando l'utente e' loggato. Bootstrap-attivato (inject dummy in `App`). All'auth.user che diventa autenticato fa max-merge tra locale e cloud; al primo signup chiama `NicknameService.findAvailable` per claimare un nickname unico. Ad ogni cambio di state mentre loggato, push debounced di 1s. Usa `firebase/firestore/lite` (no real-time, no offline persistence) per tenere il bundle sotto i 500kB.
 - `src/app/core/firebase/nickname.service.ts`: `NicknameService` gestisce la collezione `/nicknames/{nick_lowercased}` per garantire l'unicita' del nickname. Metodi: `claim(nick, uid)` atomica via runTransaction, `change(oldNick, newNick, uid)` swap atomico (release vecchio + claim nuovo + update `/users/{uid}.nickname` in una sola transazione), `findAvailable(seed, uid)` cerca varianti seed/seed2/seed3/.../seed-rnd, `getUserByNickname(nick)` per il profilo pubblico.
 - `src/app/core/firebase/user-search.service.ts`: `UserSearchService` cerca utenti per nickname con tolleranza fuzzy (Levenshtein <=2). Carica la collezione `/nicknames` intera in cache (TTL 5 min) e fa filtering/ranking client-side: match esatto > prefisso > sottostringa > distanza 1 > distanza 2. Strategia OK fino a ~2000 utenti; oltre, conviene un indice esterno tipo Algolia.
+- `src/app/core/firebase/feedback.service.ts`: `FeedbackService` scrive nella collezione `/feedback`. Rate limit lato client via localStorage (`gtc.feedback.history`), massimo 3 submission nelle ultime 24h. Le regole Firestore impongono shape e lunghezza dei campi (titolo 3-80, corpo 8-600, kind in bug/idea). Le submission sono read-only dal client: le leggi tu dalla Firebase Console.
 - `AppStateService` si abbona al signal `auth.user` via `effect`: a ogni cambio di stato Auth, riflette in `state.account` (uid, email, nickname seedato da `displayName` per Google, avatar 0 di default).
-- `firestore.rules`, `firebase.json`, `.firebaserc` alla root: config per `firebase deploy`. Schema corrente: `/users/{uid}` (stato gioco + anagrafica) e `/nicknames/{nick}` (indice unicita', non ancora popolato).
+- `firestore.rules`, `firebase.json`, `.firebaserc` alla root: config per `firebase deploy`. Schema corrente: `/users/{uid}` (stato gioco + anagrafica), `/nicknames/{nick}` (indice unicita'), `/feedback/{auto-id}` (write-only feedback dei giocatori).
 
 ### Cosa viene sincronizzato in cloud
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -33,5 +33,24 @@ service cloud.firestore {
       allow delete: if request.auth != null
                     && resource.data.uid == request.auth.uid;
     }
+
+    // /feedback/{auto-id}
+    // Write-only collection: chiunque (anche anonimo) puo' creare un
+    // documento di feedback, ma solo il proprietario del progetto puo'
+    // leggerlo (via Firebase Console). Validazione shape/lunghezza nei
+    // constraint sotto: titolo 3-80 char, corpo 8-600 char, kind in
+    // {bug, idea}. Niente update/delete dal client.
+    match /feedback/{id} {
+      allow read: if false;
+      allow create: if request.resource.data.kind in ['bug', 'idea']
+                    && request.resource.data.title is string
+                    && request.resource.data.title.size() >= 3
+                    && request.resource.data.title.size() <= 80
+                    && request.resource.data.body is string
+                    && request.resource.data.body.size() >= 8
+                    && request.resource.data.body.size() <= 600;
+      allow update: if false;
+      allow delete: if false;
+    }
   }
 }

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -62,7 +62,11 @@ export const routes: Routes = [
     canActivate: [onboardedGuard],
     loadComponent: () => import('./features/glyph-detail/glyph-detail').then((m) => m.GlyphDetail),
   },
-  { path: 'feedback',          canActivate: [onboardedGuard], loadComponent: comingSoon },
+  {
+    path: 'feedback',
+    canActivate: [onboardedGuard],
+    loadComponent: () => import('./features/feedback/feedback').then((m) => m.Feedback),
+  },
 
   // Pagina di login vera, collegata a Firebase Auth. NO onboardedGuard:
   // deve essere accessibile anche prima dell'onboarding (es. dal banner della

--- a/src/app/core/firebase/feedback.service.ts
+++ b/src/app/core/firebase/feedback.service.ts
@@ -1,0 +1,110 @@
+import { Injectable, inject } from '@angular/core';
+import {
+  Firestore,
+  addDoc,
+  collection,
+  getFirestore,
+  serverTimestamp,
+} from 'firebase/firestore/lite';
+import { ensureFirebaseApp } from './firebase';
+import { AuthService } from './auth.service';
+import { AppStateService } from '../state/app-state.service';
+import { APP_VERSION } from '../build-info';
+
+/**
+ * Invia feedback (bug o idea) alla collezione Firestore `/feedback`. Le regole
+ * permettono create da chiunque (anche anonimi) ma con vincoli su shape e
+ * lunghezza dei campi; read/update/delete sono bloccati (leggi dalla Firebase
+ * Console).
+ *
+ * Rate limit lato client (localStorage `gtc.feedback.history`): massimo 3
+ * submission nelle ultime 24 ore. Honor system: chi vuole spammare puo'
+ * azzerare il localStorage, ma raise la barriera ai casual abuse.
+ */
+@Injectable({ providedIn: 'root' })
+export class FeedbackService {
+  private readonly auth = inject(AuthService);
+  private readonly appState = inject(AppStateService);
+  private readonly db: Firestore | null;
+
+  private readonly RATE_LIMIT = 3;
+  private readonly RATE_WINDOW_MS = 24 * 60 * 60 * 1000;
+  private readonly STORAGE_KEY = 'gtc.feedback.history';
+
+  constructor() {
+    const app = ensureFirebaseApp();
+    this.db = app ? getFirestore(app) : null;
+  }
+
+  /** Quante submission restano nelle ultime 24h prima del rate limit. */
+  remainingSubmissions(): number {
+    const sent = this.recentSubmissions();
+    return Math.max(0, this.RATE_LIMIT - sent.length);
+  }
+
+  /**
+   * Invia un feedback. Ritorna 'ok' se va a buon fine, 'rate-limited' se
+   * l'utente ha gia' inviato il massimo nelle ultime 24h. Errori di rete o
+   * regole Firestore vengono lanciati.
+   */
+  async submit(input: FeedbackInput): Promise<'ok' | 'rate-limited'> {
+    if (!this.db) throw new Error('Firebase not configured');
+    if (this.remainingSubmissions() <= 0) return 'rate-limited';
+
+    const u = this.auth.user();
+    const account = this.appState.state().account;
+    const ref = collection(this.db, 'feedback');
+    await addDoc(ref, {
+      uid: u && u !== 'loading' ? u.uid : null,
+      email: input.email?.trim() || account?.email || null,
+      kind: input.kind,
+      title: input.title.trim(),
+      body: input.body.trim(),
+      meta: {
+        appVersion: APP_VERSION,
+        lang: input.lang,
+        screenWidth: typeof window !== 'undefined' ? window.innerWidth : 0,
+        screenHeight: typeof window !== 'undefined' ? window.innerHeight : 0,
+        played: this.appState.state().played,
+        streak: this.appState.state().streak,
+      },
+      createdAt: serverTimestamp(),
+    });
+    this.recordSubmission();
+    return 'ok';
+  }
+
+  /** Timestamps delle submission negli ultimi RATE_WINDOW_MS. */
+  private recentSubmissions(): number[] {
+    if (typeof localStorage === 'undefined') return [];
+    try {
+      const raw = localStorage.getItem(this.STORAGE_KEY);
+      if (!raw) return [];
+      const arr = JSON.parse(raw) as unknown;
+      if (!Array.isArray(arr)) return [];
+      const cutoff = Date.now() - this.RATE_WINDOW_MS;
+      return arr.filter((t): t is number => typeof t === 'number' && t >= cutoff);
+    } catch {
+      return [];
+    }
+  }
+
+  private recordSubmission(): void {
+    if (typeof localStorage === 'undefined') return;
+    try {
+      const recent = this.recentSubmissions();
+      recent.push(Date.now());
+      localStorage.setItem(this.STORAGE_KEY, JSON.stringify(recent));
+    } catch {
+      // ignore
+    }
+  }
+}
+
+export interface FeedbackInput {
+  kind: 'bug' | 'idea';
+  title: string;
+  body: string;
+  email?: string;
+  lang: 'it' | 'en';
+}

--- a/src/app/features/feedback/feedback.css
+++ b/src/app/features/feedback/feedback.css
@@ -1,0 +1,163 @@
+.fb-page {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding-bottom: 32px;
+}
+
+.fb-title {
+  margin: 0;
+}
+.fb-sub {
+  font-size: 13px;
+  margin: 0;
+  line-height: 1.5;
+}
+
+/* Switch bug/idea: riusa .seg globale ma aggiungiamo emoji-spacing. */
+.fb-kind {
+  margin-top: 4px;
+}
+.fb-kind .seg-btn {
+  gap: 6px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.fb-form {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.fb-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  position: relative;
+}
+.fb-field-label {
+  font-size: 12px;
+  color: var(--text-dim);
+}
+
+/* Riusa .input-field globale, gia' definito in login.css come scoped:
+   qui ridefiniamo nel contesto della pagina feedback. */
+.input-field {
+  width: 100%;
+  padding: 12px 14px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  color: var(--text);
+  font-size: 14px;
+  font-family: inherit;
+  outline: none;
+  box-sizing: border-box;
+  transition: border-color var(--hover-dur) ease;
+}
+.input-field:focus { border-color: var(--accent); }
+.fb-textarea {
+  resize: vertical;
+  min-height: 110px;
+  line-height: 1.45;
+}
+
+.fb-counter {
+  position: absolute;
+  right: 4px;
+  bottom: -16px;
+  font-size: 11px;
+  color: var(--text-mute);
+}
+
+/* "Cosa includo": expandable col preview del metadata tecnico in mono. */
+.fb-meta {
+  font-size: 12px;
+  color: var(--text-dim);
+}
+.fb-meta summary {
+  cursor: pointer;
+  user-select: none;
+  padding: 4px 0;
+}
+.fb-meta-pre {
+  margin: 8px 0 0;
+  padding: 10px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  font-size: 11px;
+  overflow-x: auto;
+  color: var(--text-mute);
+  line-height: 1.55;
+  white-space: pre;
+}
+
+.fb-error {
+  margin: 0;
+  padding: 10px 12px;
+  background: rgba(251, 113, 133, 0.08);
+  border: 1px solid rgba(251, 113, 133, 0.35);
+  color: var(--danger);
+  border-radius: 10px;
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.fb-rate-hint,
+.fb-rate-warning {
+  font-size: 11px;
+  text-align: center;
+  margin: 0;
+}
+.fb-rate-warning {
+  color: var(--warm);
+}
+
+.fb-submit {
+  margin-top: 4px;
+}
+
+/* Stato di successo: tick verde grande + titolo + bottoni. */
+.fb-success {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 12px;
+  padding: 40px 16px 24px;
+}
+.fb-success-tick {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  background: rgba(52, 211, 153, 0.15);
+  border: 1px solid rgba(52, 211, 153, 0.35);
+  color: var(--success);
+  display: grid;
+  place-items: center;
+  animation: fb-pop 0.3s ease;
+}
+@keyframes fb-pop {
+  0%   { transform: scale(0.8); opacity: 0; }
+  100% { transform: scale(1); opacity: 1; }
+}
+[data-motion="minimal"] .fb-success-tick {
+  animation: none;
+}
+.fb-success p {
+  max-width: 320px;
+  font-size: 14px;
+  line-height: 1.5;
+  margin: 0;
+}
+.fb-success-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+  max-width: 280px;
+  margin-top: 8px;
+}

--- a/src/app/features/feedback/feedback.html
+++ b/src/app/features/feedback/feedback.html
@@ -1,0 +1,145 @@
+<div class="app-shell">
+  <app-bar [canBack]="true"
+           [title]="i18n.lang() === 'it' ? 'Feedback' : 'Feedback'"
+           (back)="goBack()"
+           (goHome)="goHome()" />
+
+  <div class="page fb-page">
+    @if (submitted()) {
+      <!-- Stato di successo: tick verde grande + titolo + bottoni. -->
+      <div class="fb-success">
+        <div class="fb-success-tick" aria-hidden="true">
+          <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M5 12l5 5L20 7"/>
+          </svg>
+        </div>
+        <h2 class="h2">{{ i18n.lang() === 'it' ? 'Grazie!' : 'Thanks!' }}</h2>
+        <p class="muted">
+          {{ i18n.lang() === 'it'
+            ? 'Il tuo feedback e\' arrivato. Lo leggero\' presto.'
+            : 'Your feedback has arrived. I\'ll read it soon.' }}
+        </p>
+        <div class="fb-success-actions">
+          @if (remaining() > 0) {
+            <button class="btn btn-ghost" type="button" (click)="sendAnother()">
+              {{ i18n.lang() === 'it' ? 'Mandane un altro' : 'Send another' }}
+            </button>
+          }
+          <button class="btn btn-primary" type="button" (click)="goHome()">
+            {{ i18n.lang() === 'it' ? 'Torna alla home' : 'Back to home' }}
+          </button>
+        </div>
+      </div>
+    } @else {
+      <h2 class="h2 fb-title">
+        {{ i18n.lang() === 'it' ? 'Aiuta a migliorare' : 'Help me improve' }}
+      </h2>
+      <p class="muted fb-sub">
+        {{ i18n.lang() === 'it'
+          ? 'Trovi un bug o hai un\'idea? Mandala qui sotto.'
+          : 'Found a bug or have an idea? Send it below.' }}
+      </p>
+
+      <!-- Switch bug / idea: identico al pattern .seg degli altri toggle. -->
+      <div class="seg fb-kind">
+        <button type="button" class="seg-btn"
+                [class.is-active]="kind() === 'bug'"
+                (click)="setKind('bug')">
+          <span aria-hidden="true">🐞</span>
+          {{ i18n.lang() === 'it' ? 'Segnala bug' : 'Report bug' }}
+        </button>
+        <button type="button" class="seg-btn"
+                [class.is-active]="kind() === 'idea'"
+                (click)="setKind('idea')">
+          <span aria-hidden="true">💡</span>
+          {{ i18n.lang() === 'it' ? 'Suggerisci idea' : 'Suggest idea' }}
+        </button>
+      </div>
+
+      <form class="fb-form" (ngSubmit)="submit()">
+        <label class="fb-field">
+          <span class="fb-field-label">
+            @if (kind() === 'bug') {
+              {{ i18n.lang() === 'it' ? 'Cosa e\' andato storto?' : 'What went wrong?' }}
+            } @else {
+              {{ i18n.lang() === 'it' ? 'In una riga, qual e\' l\'idea?' : 'In one line, what\'s the idea?' }}
+            }
+          </span>
+          <input class="input-field"
+                 type="text"
+                 [ngModel]="title()"
+                 (ngModelChange)="setTitle($event)"
+                 maxlength="80"
+                 minlength="3"
+                 name="fbTitle"
+                 [placeholder]="titlePlaceholder()" />
+        </label>
+
+        <label class="fb-field">
+          <span class="fb-field-label">
+            {{ i18n.lang() === 'it' ? 'Dettagli' : 'Details' }}
+          </span>
+          <textarea class="input-field fb-textarea"
+                    rows="5"
+                    maxlength="600"
+                    minlength="8"
+                    [ngModel]="body()"
+                    (ngModelChange)="setBody($event)"
+                    name="fbBody"
+                    [placeholder]="bodyPlaceholder()"></textarea>
+          <span class="fb-counter mono">{{ body().length }}/600</span>
+        </label>
+
+        @if (!appState.state().account) {
+          <label class="fb-field">
+            <span class="fb-field-label">
+              {{ i18n.lang() === 'it' ? 'Email (opzionale, per ricontatto)' : 'Email (optional, for follow-up)' }}
+            </span>
+            <input class="input-field"
+                   type="email"
+                   [ngModel]="email()"
+                   (ngModelChange)="setEmail($event)"
+                   name="fbEmail"
+                   placeholder="tu@esempio.it" />
+          </label>
+        }
+
+        <!-- Cosa includo: metadata tecnica raccolta in automatico. -->
+        <details class="fb-meta">
+          <summary>
+            {{ i18n.lang() === 'it' ? 'Cosa includo' : 'What I include' }}
+          </summary>
+          <pre class="mono fb-meta-pre">{{ metaPreview() }}</pre>
+        </details>
+
+        @if (error(); as e) {
+          <p class="fb-error" role="alert">{{ e }}</p>
+        }
+
+        @if (remaining() === 0) {
+          <p class="muted fb-rate-warning">
+            {{ i18n.lang() === 'it'
+              ? 'Hai esaurito le 3 segnalazioni giornaliere. Riprova domani.'
+              : 'You\'ve used your 3 daily reports. Try again tomorrow.' }}
+          </p>
+        } @else {
+          <p class="muted fb-rate-hint">
+            {{ i18n.lang() === 'it'
+              ? 'Puoi inviare ancora ' + remaining() + ' feedback oggi.'
+              : 'You can send ' + remaining() + ' more feedback today.' }}
+          </p>
+        }
+
+        <button class="btn btn-primary btn-block fb-submit"
+                type="submit"
+                [disabled]="!canSubmit()">
+          @if (busy()) {
+            {{ i18n.lang() === 'it' ? 'Invio...' : 'Sending...' }}
+          } @else {
+            {{ i18n.lang() === 'it' ? 'Invia' : 'Send' }}
+          }
+        </button>
+      </form>
+    }
+  </div>
+</div>

--- a/src/app/features/feedback/feedback.ts
+++ b/src/app/features/feedback/feedback.ts
@@ -1,0 +1,147 @@
+import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
+import { Location } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { Router } from '@angular/router';
+import { I18nService } from '../../core/i18n/i18n.service';
+import { AppStateService } from '../../core/state/app-state.service';
+import { FeedbackService } from '../../core/firebase/feedback.service';
+import { AppBar } from '../../shared/app-bar';
+import { APP_VERSION } from '../../core/build-info';
+
+type Kind = 'bug' | 'idea';
+
+@Component({
+  selector: 'app-feedback',
+  imports: [AppBar, FormsModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './feedback.html',
+  styleUrl: './feedback.css',
+})
+export class Feedback {
+  private readonly router = inject(Router);
+  private readonly location = inject(Location);
+  protected readonly i18n = inject(I18nService);
+  protected readonly appState = inject(AppStateService);
+  private readonly fbSvc = inject(FeedbackService);
+
+  protected readonly kind = signal<Kind>('bug');
+  protected readonly title = signal('');
+  protected readonly body = signal('');
+  protected readonly email = signal('');
+  protected readonly busy = signal(false);
+  protected readonly submitted = signal(false);
+  protected readonly error = signal<string | null>(null);
+
+  /** Quante submission restano oggi (3 al giorno). */
+  protected readonly remaining = signal(this.fbSvc.remainingSubmissions());
+
+  protected readonly titleValid = computed(() => {
+    const t = this.title().trim();
+    return t.length >= 3 && t.length <= 80;
+  });
+  protected readonly bodyValid = computed(() => {
+    const b = this.body().trim();
+    return b.length >= 8 && b.length <= 600;
+  });
+  protected readonly canSubmit = computed(
+    () =>
+      this.titleValid() &&
+      this.bodyValid() &&
+      !this.busy() &&
+      this.remaining() > 0,
+  );
+
+  /** Placeholder dinamici per i campi (cambiano in base a bug/idea + lingua). */
+  protected readonly titlePlaceholder = computed(() => {
+    const isIt = this.i18n.lang() === 'it';
+    if (this.kind() === 'bug') {
+      return isIt
+        ? 'es. Il timer non riparte dopo la pausa'
+        : 'e.g. Timer does not restart after pause';
+    }
+    return isIt ? "es. Modalita' per scritture estinte" : 'e.g. Mode for extinct scripts';
+  });
+  protected readonly bodyPlaceholder = computed(() => {
+    const isIt = this.i18n.lang() === 'it';
+    if (this.kind() === 'bug') {
+      return isIt
+        ? "Come e' successo? Cosa ti aspettavi?"
+        : 'How did it happen? What did you expect?';
+    }
+    return isIt ? 'Come la useresti? A che scopo serve?' : 'How would you use it? What problem does it solve?';
+  });
+
+  /** Info che viene inclusa col feedback, mostrate nell'expandable. */
+  protected readonly metaPreview = computed(() => {
+    const s = this.appState.state();
+    const w = typeof window !== 'undefined' ? window.innerWidth : 0;
+    const h = typeof window !== 'undefined' ? window.innerHeight : 0;
+    return `app: ${APP_VERSION}\nlang: ${this.i18n.lang()}\nscreen: ${w}x${h}\nplayed: ${s.played}, streak: ${s.streak}`;
+  });
+
+  protected setKind(k: Kind): void {
+    this.kind.set(k);
+    this.error.set(null);
+  }
+  protected setTitle(v: string): void {
+    this.title.set(v);
+    if (this.error()) this.error.set(null);
+  }
+  protected setBody(v: string): void {
+    this.body.set(v);
+    if (this.error()) this.error.set(null);
+  }
+  protected setEmail(v: string): void {
+    this.email.set(v);
+  }
+
+  protected async submit(): Promise<void> {
+    if (!this.canSubmit()) return;
+    this.busy.set(true);
+    this.error.set(null);
+    try {
+      const r = await this.fbSvc.submit({
+        kind: this.kind(),
+        title: this.title(),
+        body: this.body(),
+        email: this.email(),
+        lang: this.i18n.lang(),
+      });
+      if (r === 'rate-limited') {
+        this.error.set(
+          this.i18n.lang() === 'it'
+            ? 'Hai gia\' inviato 3 feedback nelle ultime 24 ore. Riprova domani.'
+            : "You've already sent 3 feedbacks in the last 24 hours. Try again tomorrow.",
+        );
+        return;
+      }
+      this.submitted.set(true);
+      this.remaining.set(this.fbSvc.remainingSubmissions());
+    } catch (e: unknown) {
+      console.warn('[feedback] submit error:', e);
+      this.error.set(
+        this.i18n.lang() === 'it'
+          ? 'Errore di invio. Controlla la connessione e riprova.'
+          : 'Send error. Check your connection and try again.',
+      );
+    } finally {
+      this.busy.set(false);
+    }
+  }
+
+  protected sendAnother(): void {
+    this.submitted.set(false);
+    this.kind.set('bug');
+    this.title.set('');
+    this.body.set('');
+    this.error.set(null);
+    this.remaining.set(this.fbSvc.remainingSubmissions());
+  }
+
+  protected goBack(): void {
+    this.location.back();
+  }
+  protected goHome(): void {
+    this.router.navigate(['/home']);
+  }
+}


### PR DESCRIPTION
Sostituisce il placeholder /feedback con una pagina vera. Le segnalazioni arrivano su Firestore e si leggono dalla Firebase Console.

UX

La voce 'Segnala bug o suggerisci un'idea' in Impostazioni > Aiuto, e il link Feedback in fondo alla home, ora portano a una pagina con:
- toggle Bug / Idea con emoji 🐞 e 💡
- titolo (3-80 char) con placeholder che cambia in base al kind
- dettagli (8-600 char) con counter
- email opzionale (visibile solo se non sei loggato; per chi e' loggato la prendiamo dall'account)
- expandable Cosa includo che mostra appVersion, lang, screen size, played e streak
- contatore 'Puoi inviare ancora N feedback oggi' in basso
- bottone Invia disabilitato finche' titolo e corpo non sono validi

Dopo il submit, stato di successo: tick verde animato, titolo Grazie!, e due bottoni Mandane un altro / Torna alla home.

Backend

Nuova collezione /feedback in Firestore con regole write-only dal client. Le rules impongono:
- kind in {bug, idea}
- title is string, lunghezza 3-80
- body is string, lunghezza 8-600
- read/update/delete bloccati: tu leggi le segnalazioni dalla Firebase Console

Documento shape:
{
  uid: string | null,         // null per anonimi
  email: string | null,
  kind: 'bug' | 'idea',
  title: string,
  body: string,
  meta: {
    appVersion, lang, screenWidth, screenHeight, played, streak
  },
  createdAt: serverTimestamp
}

Rate limit

Lato client via localStorage gtc.feedback.history: array di timestamp delle submission, filtrato a quelle nelle ultime 24h. Massimo 3 ogni 24h per dispositivo. La pagina mostra in tempo reale quante ne restano. Honor system: l'utente piu' motivato puo' azzerare il localStorage, ma raise la barriera ai casual abuse.

Per veri rate limit server-side servirebbe Cloud Functions, e questo for now e' overkill.

Setup richiesto una-tantum

Lanciare 'npm run deploy:rules' per pubblicare le nuove regole su Firestore. Senza, le write su /feedback verrebbero rifiutate.

Cosa NON in questa PR

Modale/sheet invece di pagina: il mockup usava uno sheet. Una pagina full route e' piu' semplice (deep-link, history) ed essere gia' il pattern dell'app. Se si volesse il pattern modale come nel mockup, sara' refactor in PR successiva.

Lettura dei feedback ricevuti dentro l'app: read e' bloccato dalle rules. Per ora se vuoi vedere quanto ricevuto, vai su Firebase Console > Firestore > /feedback. Una mini UI admin potrebbe arrivare quando avro' voglia.