### PR TITLE
fix(firebase): migrazione automatica del nickname per utenti legacy

### DIFF
--- a/src/app/core/firebase/user-doc.service.ts
+++ b/src/app/core/firebase/user-doc.service.ts
@@ -161,6 +161,38 @@ export class UserDocService {
         { ...toCloudShape(merged, user), updatedAt: serverTimestamp() },
         { merge: true },
       );
+      // Migrazione utenti legacy: alcuni account creati prima che la
+      // collezione /nicknames esistesse (o per cui il claim e' fallito
+      // silenziosamente all'epoca) hanno una entry in /users ma niente in
+      // /nicknames. Senza entry, search e profilo pubblico non li trovano.
+      // findAvailable e' idempotente: se gia' possiedi il nickname, no-op;
+      // se non esiste, lo claim ora; se qualcun altro lo ha rubato nel
+      // frattempo, ti assegna una variante (es. nick2). In quest'ultimo caso
+      // aggiorniamo state.account.nickname per restare consistenti.
+      try {
+        const currentNick = merged.account?.nickname ?? user.displayName ?? '';
+        if (currentNick) {
+          const owned = await this.nicknames.findAvailable(currentNick, user.uid);
+          if (owned !== currentNick) {
+            // Era stato preso da qualcun altro; passiamo alla variante.
+            this.applyingMerge = true;
+            try {
+              this.appState.updateAccount({ nickname: owned });
+            } finally {
+              queueMicrotask(() => {
+                this.applyingMerge = false;
+              });
+            }
+            await setDoc(
+              ref,
+              { nickname: owned, updatedAt: serverTimestamp() },
+              { merge: true },
+            );
+          }
+        }
+      } catch (e) {
+        console.warn('[firestore] legacy nickname claim failed:', e);
+      }
     } catch (e) {
       console.warn('[firestore] sync merge error:', e);
     }


### PR DESCRIPTION
Risolve il caso 'imilly628 esiste in /users ma non in /nicknames, e quindi la ricerca non lo trova'.

Cause del problema

Alcuni utenti hanno una entry in /users ma manca in /nicknames. Due possibili motivi:
1. Si sono registrati prima della PR #51 che ha introdotto NicknameService e la claim automatica al primo login
2. La claim e' fallita silenziosamente al primo login (errore di rete temporaneo, race, ecc.)

Sia /cerca sia /u/{nickname} usano /nicknames come indice di lookup (nickname lowercased -> uid), quindi questi utenti risultano invisibili.

Fix

In UserDocService.onLogin, dopo il merge dei progressi sul ramo doc-esistente, chiamiamo nicknames.findAvailable(currentNick, uid). E' idempotente: 
- se l'utente possiede gia' quel nickname in /nicknames: no-op (la transazione vede 'taken-by-me' e ritorna senza scrivere)
- se /nicknames/{nick} non esiste: claim atomica subito
- se nel frattempo qualcun altro ha claimato quel nickname: findAvailable trova alessio.pes2, alessio.pes3 ecc. e lo restituisce. In quel caso aggiorniamo state.account.nickname locale e scriviamo il nickname nuovo su /users via setDoc({merge: true}).

Per la stragrande maggioranza degli utenti l'operazione e' una read aggiuntiva (~50 byte) e niente write: trascurabile. Per i legacy come imilly628, al loro prossimo login l'entry in /nicknames viene creata in automatico e da li' in poi sono ricercabili.

Niente migrazione una-tantum richiesta: si auto-ripara al traffico naturale.

Architettura

Riconfermo la scelta di tenere /nicknames separata da /users. Tre motivi: (1) Firestore non ha vincoli UNIQUE nativi su un campo, l'unico modo affidabile e' usare il nickname come document ID di una collezione dedicata; (2) /nicknames docs sono piccoli (~50 byte vs ~500 di /users), 10x meno banda e costi per query; (3) il bug attuale e' una migrazione mancante, non un problema di design.