### PR TITLE
fix(settings): footer mostra solo la versione, niente 'static · offline-ready'

### DIFF
--- a/src/app/features/settings/settings.html
+++ b/src/app/features/settings/settings.html
@@ -176,6 +176,6 @@
       </button>
     </div>
 
-    <p class="settings-footer mono">{{ buildLabel }} · static · offline-ready</p>
+    <p class="settings-footer mono">{{ buildLabel }}</p>
   </div>
 </div>


### PR DESCRIPTION
In produzione il footer della pagina impostazioni mostrava 'v1.x.x · static · offline-ready'. La parte dopo la versione e' jargon tecnico (era nel mockup come anteprima dev), inutile per chi gioca. Ora mostra solo buildLabel, che in produzione e' 'vX.Y.Z' e in sviluppo 'vX.Y.Z · dev · abc1234'. Allineato al footer della home.