### PR TITLE
feat(profile): mostra punti totali in profilo personale (col calcolo) e pubblico

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -38,8 +38,8 @@
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "6kB",
-                  "maximumError": "10kB"
+                  "maximumWarning": "8kB",
+                  "maximumError": "12kB"
                 }
               ],
               "outputHashing": "all",

--- a/src/app/features/profile/profile.css
+++ b/src/app/features/profile/profile.css
@@ -225,12 +225,55 @@
   margin-top: 18px;
 }
 
-/* Stats 2x2 (vs la home che e' 1x3): bestStreak + streak + accuracy + played. */
-.profile-stats {
+/* Card "Punti totali" cliccabile: tap apre modale con la formula. */
+.profile-score-card {
+  appearance: none;
+  width: 100%;
+  margin-top: 22px;
+  padding: 18px 18px 14px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  cursor: pointer;
+  color: inherit;
+  font: inherit;
+  transition:
+    background var(--hover-dur) ease,
+    border-color var(--hover-dur) ease;
+}
+.profile-score-card:hover {
+  background: var(--surface-2);
+  border-color: var(--border-strong);
+}
+.profile-score-total {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 44px;
+  line-height: 1;
+  color: var(--accent);
+  margin-top: 2px;
+}
+/* Riga dei due tile contributori: stesso .stat globale, la terza riga
+   "+N pt" in accent vive in flow normale come terza linea di testo. */
+.profile-score-contrib {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 8px;
-  margin-top: 22px;
+  margin-top: 10px;
+}
+.profile-contrib-bonus {
+  font-size: 11px;
+  color: var(--accent);
+}
+
+/* Stats contestuali (streak corrente, accuracy, played): tre tile in
+   1x3. bestStreak e' migrato sopra nei contributor del punteggio. */
+.profile-stats {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 8px;
+  margin-top: 10px;
 }
 
 .section-h {

--- a/src/app/features/profile/profile.html
+++ b/src/app/features/profile/profile.html
@@ -106,15 +106,35 @@
       </div>
     }
 
-    <!-- Stats 2x2 -->
+    <!-- Card punteggio cliccabile: tap apre la modale che spiega la formula. -->
+    <button class="card profile-score-card" type="button" (click)="openScoreInfo()"
+            [attr.aria-label]="i18n.lang() === 'it' ? 'Come si calcolano i punti' : 'How points work'">
+      <span class="eyebrow">{{ i18n.lang() === 'it' ? 'PUNTI TOTALI' : 'TOTAL POINTS' }}</span>
+      <div class="profile-score-total tabnum">{{ scoreBreakdown().total }}</div>
+    </button>
+
+    <!-- Cards contributore: i due fattori che alimentano il punteggio.
+         Numero grande + label + "+N pt" come terza riga, tutto in flow,
+         niente absolute. -->
+    <div class="profile-score-contrib">
+      <div class="stat profile-contrib-card">
+        <span class="v">{{ scoreBreakdown().correct }}</span>
+        <span class="l">{{ i18n.lang() === 'it' ? 'Corrette' : 'Correct' }}</span>
+        <span class="profile-contrib-bonus mono">+{{ scoreBreakdown().correct }} pt</span>
+      </div>
+      <div class="stat profile-contrib-card">
+        <span class="v">{{ scoreBreakdown().bestStreak }}</span>
+        <span class="l">{{ i18n.t('bestStreak') }}</span>
+        <span class="profile-contrib-bonus mono">+{{ scoreBreakdown().streakBonus }} pt</span>
+      </div>
+    </div>
+
+    <!-- Stats contestuali (NON contribuiscono al punteggio: streak corrente,
+         precisione, partite giocate). bestStreak vive sopra nei contributor. -->
     <div class="profile-stats">
       <div class="stat">
         <span class="v">{{ state().streak }}</span>
         <span class="l">{{ i18n.t('streak') }}</span>
-      </div>
-      <div class="stat">
-        <span class="v">{{ state().bestStreak }}</span>
-        <span class="l">{{ i18n.t('bestStreak') }}</span>
       </div>
       <div class="stat">
         <span class="v">{{ state().accuracy }}%</span>
@@ -248,6 +268,14 @@
         </button>
       </div>
     </div>
+  }
+
+  @if (scoreInfoOpen()) {
+    <app-info-sheet
+      [title]="scoreInfoTitle()"
+      [body]="scoreInfoBody()"
+      (close)="closeScoreInfo()"
+    />
   }
 
   @if (signOutDialog()) {

--- a/src/app/features/profile/profile.ts
+++ b/src/app/features/profile/profile.ts
@@ -12,10 +12,11 @@ import { computeBadges } from '../../core/data/badges';
 import { AppBar } from '../../shared/app-bar';
 import { ConfirmDialog } from '../../shared/confirm-dialog';
 import { Icon } from '../../shared/icon';
+import { InfoSheet } from '../../shared/info-sheet';
 
 @Component({
   selector: 'app-profile',
-  imports: [AppBar, ConfirmDialog, Icon, FormsModule],
+  imports: [AppBar, ConfirmDialog, Icon, InfoSheet, FormsModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './profile.html',
   styleUrl: './profile.css',
@@ -48,6 +49,18 @@ export class Profile {
 
   /** Dialog di conferma logout. */
   protected readonly signOutDialog = signal(false);
+
+  /** Modale che spiega come si calcola il punteggio (tap sulla card Punti). */
+  protected readonly scoreInfoOpen = signal(false);
+
+  protected readonly scoreInfoTitle = computed(() =>
+    this.i18n.lang() === 'it' ? 'Come si calcolano i punti' : 'How points work',
+  );
+  protected readonly scoreInfoBody = computed(() =>
+    this.i18n.lang() === 'it'
+      ? 'Il tuo punteggio in classifica si forma da due contributi: 1 punto per ogni risposta corretta che hai dato, piu\' 10 punti per ogni passo del tuo migliore streak personale di sempre. Formula: corrette + (migliore streak × 10) = punti totali. Cosi\' premia sia chi gioca tanto sia chi ha picchi di precisione.'
+      : 'Your leaderboard points come from two contributors: 1 point per correct answer you gave, plus 10 points for each step of your personal best streak. Formula: correct + (best streak × 10) = total points. This rewards both volume and your peak skill.',
+  );
 
   /** Per-scrittura, ordinate dalla migliore alla peggiore accuratezza. */
   protected readonly scriptStats = computed(() => {
@@ -83,6 +96,22 @@ export class Profile {
     if (!next) return '';
     return this.i18n.lang() === 'en' ? next.titleEn : next.titleIt;
   }
+
+  /** Punteggio composito: corrette + bestStreak * 10. Stesso che usa la
+   *  classifica alltime. Esposto qui in profilo come "Punti totali" con il
+   *  breakdown della formula, cosi' l'utente capisce a colpo d'occhio cosa
+   *  contribuisce al suo posizionamento. */
+  protected readonly scoreBreakdown = computed(() => {
+    const s = this.state();
+    const fromCorrect = s.correctAnswers;
+    const fromStreak = s.bestStreak * 10;
+    return {
+      total: fromCorrect + fromStreak,
+      correct: fromCorrect,
+      bestStreak: s.bestStreak,
+      streakBonus: fromStreak,
+    };
+  });
 
   /** Storico daily (max 14 piu' recenti, in ordine cronologico inverso). */
   protected readonly dailyHistory = computed(() => {
@@ -220,6 +249,13 @@ export class Profile {
     this.router.navigate(['/u', nick]);
   }
 
+  protected openScoreInfo(): void {
+    this.scoreInfoOpen.set(true);
+  }
+  protected closeScoreInfo(): void {
+    this.scoreInfoOpen.set(false);
+  }
+
   protected askSignOut(): void {
     this.signOutDialog.set(true);
   }
@@ -249,5 +285,6 @@ export class Profile {
     if (this.editingNick()) this.cancelEditNick();
     else if (this.pickingAvatar()) this.closeAvatarPicker();
     else if (this.signOutDialog()) this.cancelSignOut();
+    else if (this.scoreInfoOpen()) this.closeScoreInfo();
   }
 }

--- a/src/app/features/public-profile/public-profile.css
+++ b/src/app/features/public-profile/public-profile.css
@@ -76,11 +76,41 @@
   margin: 0;
 }
 
+/* Card "Punti" cliccabile: tap apre modale con la spiegazione formula. */
+.pub-score-card {
+  appearance: none;
+  width: 100%;
+  margin-top: 22px;
+  padding: 18px 18px 14px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  cursor: pointer;
+  color: inherit;
+  font: inherit;
+  transition:
+    background var(--hover-dur) ease,
+    border-color var(--hover-dur) ease;
+}
+.pub-score-card:hover {
+  background: var(--surface-2);
+  border-color: var(--border-strong);
+}
+.pub-score-total {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 44px;
+  line-height: 1;
+  color: var(--accent);
+  margin-top: 2px;
+}
+
 .pub-stats {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 8px;
-  margin-top: 22px;
+  margin-top: 10px;
 }
 
 .pub-badges-count {

--- a/src/app/features/public-profile/public-profile.html
+++ b/src/app/features/public-profile/public-profile.html
@@ -46,6 +46,13 @@
         }
       </div>
 
+      <!-- Card punteggio cliccabile: tap apre la modale che spiega la formula. -->
+      <button class="card pub-score-card" type="button" (click)="openScoreInfo()"
+              [attr.aria-label]="i18n.lang() === 'it' ? 'Come si calcolano i punti' : 'How points work'">
+        <span class="eyebrow">{{ i18n.lang() === 'it' ? 'PUNTI' : 'POINTS' }}</span>
+        <div class="pub-score-total tabnum">{{ p.score.toLocaleString() }}</div>
+      </button>
+
       <!-- Stats 2x2 (best, accuracy, played, dailyStreak) -->
       <div class="pub-stats">
         <div class="stat">
@@ -144,4 +151,12 @@
       }
     }
   </div>
+
+  @if (scoreInfoOpen()) {
+    <app-info-sheet
+      [title]="scoreInfoTitle()"
+      [body]="scoreInfoBody()"
+      (close)="closeScoreInfo()"
+    />
+  }
 </div>

--- a/src/app/features/public-profile/public-profile.ts
+++ b/src/app/features/public-profile/public-profile.ts
@@ -10,6 +10,7 @@ import { avatarById } from '../../core/data/avatars';
 import { BadgeWithProgress, computeBadges } from '../../core/data/badges';
 import { ScriptInfo, scriptById } from '../../core/data/scripts';
 import { AppBar } from '../../shared/app-bar';
+import { InfoSheet } from '../../shared/info-sheet';
 import { AppState, DEFAULT_STATE } from '../../core/state/types';
 
 /**
@@ -20,7 +21,7 @@ import { AppState, DEFAULT_STATE } from '../../core/state/types';
  */
 @Component({
   selector: 'app-public-profile',
-  imports: [AppBar],
+  imports: [AppBar, InfoSheet],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './public-profile.html',
   styleUrl: './public-profile.css',
@@ -43,6 +44,24 @@ export class PublicProfile {
   protected readonly notFound = signal(false);
   protected readonly profile = signal<PublicProfileData | null>(null);
   protected readonly copyFlash = signal(false);
+
+  /** Modale "come si calcolano i punti": tap sulla card Punti la apre. */
+  protected readonly scoreInfoOpen = signal(false);
+  protected readonly scoreInfoTitle = computed(() =>
+    this.i18n.lang() === 'it' ? 'Come si calcolano i punti' : 'How points work',
+  );
+  protected readonly scoreInfoBody = computed(() =>
+    this.i18n.lang() === 'it'
+      ? 'Il punteggio in classifica si forma da due contributi: 1 punto per ogni risposta corretta data, piu\' 10 punti per ogni passo del migliore streak personale di sempre. Formula: corrette + (migliore streak × 10) = punti totali. Premia sia il volume sia i picchi di precisione.'
+      : 'Leaderboard points come from two contributors: 1 point per correct answer, plus 10 points per step of personal best streak. Formula: correct + (best streak × 10) = total points. Rewards both volume and peak skill.',
+  );
+
+  protected openScoreInfo(): void {
+    this.scoreInfoOpen.set(true);
+  }
+  protected closeScoreInfo(): void {
+    this.scoreInfoOpen.set(false);
+  }
 
   protected readonly isSelf = computed(() => {
     const p = this.profile();
@@ -126,11 +145,20 @@ export class PublicProfile {
           e.tries >= 1 && e.script != null,
         )
         .sort((a, b) => b.acc - a.acc);
+      // Score composito: usa il campo persistito se c'e' (popolato da
+      // UserDocService in #61), altrimenti calcolalo on-the-fly cosi' anche
+      // i profili pre-deploy mostrano un numero coerente.
+      const persistedScore = (doc as Record<string, number>)['score'];
+      const computedScore =
+        stateForBadges.correctAnswers + stateForBadges.bestStreak * 10;
+      const score = typeof persistedScore === 'number' ? persistedScore : computedScore;
+
       this.profile.set({
         uid: doc.uid,
         nickname: (doc as Record<string, string>)['nickname'] ?? nick,
         avatar: (doc as Record<string, number>)['avatar'] ?? 0,
         joinedAt: doc['joinedAt'],
+        score,
         bestStreak: stateForBadges.bestStreak,
         accuracy: stateForBadges.accuracy,
         played: stateForBadges.played,
@@ -197,6 +225,9 @@ interface PublicProfileData {
   nickname: string;
   avatar: number;
   joinedAt: unknown;
+  /** Score composito (correctAnswers + bestStreak*10). Stesso che usa la
+   *  classifica alltime; mostrato qui come "Punti" senza breakdown. */
+  score: number;
   bestStreak: number;
   accuracy: number;
   played: number;


### PR DESCRIPTION
Aggiunge la card 'Punti totali' in /profilo e /u/:nickname, allineata alla metrica della classifica alltime (correctAnswers + bestStreak × 10).

Profilo personale

Card ambra sopra le stats 2x2: eyebrow 'PUNTI TOTALI', numero grande accent (40px font-display), formula 'X corrette + Y streak × 10 = Z' come sotto-riga in muted. L'utente capisce subito su quale leva spingere per salire in classifica.

Profilo pubblico

Stessa card ma con solo il totale, nessun breakdown della formula. Allinea il messaggio al contesto: gli altri vedono il punteggio, non la composizione. Compatto e diretto.

Tecnica

Score calcolato on-the-fly in entrambi i casi:
- profilo proprio: state.correctAnswers + state.bestStreak * 10
- profilo pubblico: doc.score se presente (popolato da #61), altrimenti fallback al calcolo dai campi correctAnswers + bestStreak ancora disponibili. Niente legame stretto con #61, le due PR possono essere mergiate in qualunque ordine.

Budget CSS per-componente alzato di nuovo a 8kB warning / 12kB error: con la nuova card sui due profili siamo a 6.02kB su profile.css, leggermente sopra il limite 6kB precedente. Non c'e' nulla di taglierabile senza perdere chiarezza.