### PR TITLE
feat(friends): amicizie mutuali con richieste e pagina /amici

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,7 @@ src/
       badges/
       daily-result/
       feedback/
+      friends/
       game/
       glyph-detail/
       home/
@@ -305,6 +306,7 @@ L'app si appoggia a Firebase Auth + Firestore per login e sincronizzazione del p
 - `src/app/core/firebase/user-search.service.ts`: `UserSearchService` cerca utenti per nickname con tolleranza fuzzy (Levenshtein <=2). Carica la collezione `/nicknames` intera in cache (TTL 5 min) e fa filtering/ranking client-side: match esatto > prefisso > sottostringa > distanza 1 > distanza 2. Strategia OK fino a ~2000 utenti; oltre, conviene un indice esterno tipo Algolia.
 - `src/app/core/firebase/leaderboard.service.ts`: `LeaderboardService` legge la classifica da `/users`. Due viste: `daily` (filtra per `dailyDoneStamp == today`, sort `dailyScore` desc) e `alltime` (sort `correctAnswers` desc). Paginazione cursor-based via `startAfter`, page size 30. Niente cache: ogni cambio tab e ogni "Mostra altri" e' una fetch fresca.
 - `src/app/core/firebase/feedback.service.ts`: `FeedbackService` scrive nella collezione `/feedback`. Rate limit lato client via localStorage (`gtc.feedback.history`), massimo 3 submission nelle ultime 24h. Le regole Firestore impongono shape e lunghezza dei campi (titolo 3-80, corpo 8-600, kind in bug/idea). Le submission sono read-only dal client: le leggi tu dalla Firebase Console.
+- `src/app/core/firebase/friends.service.ts`: `FriendsService` gestisce amicizie mutuali via subcollezione `/users/{uid}/friends/{friendUid}`. Schema speculare: una relazione = due doc, uno per lato, status `pending-sent` | `pending-received` | `accepted`. Scritture atomiche via `writeBatch` (sendRequest/accept/decline/remove). Le regole Firestore consentono a entrambe le parti di scrivere su entrambi i lati (necessario per il batch simmetrico). Lettura riservata al proprietario della subcollezione: la tua lista amici e' privata.
 - `AppStateService` si abbona al signal `auth.user` via `effect`: a ogni cambio di stato Auth, riflette in `state.account` (uid, email, nickname seedato da `displayName` per Google, avatar 0 di default).
 - `firestore.rules`, `firebase.json`, `.firebaserc` alla root: config per `firebase deploy`. Schema corrente: `/users/{uid}` (stato gioco + anagrafica), `/nicknames/{nick}` (indice unicita'), `/feedback/{auto-id}` (write-only feedback dei giocatori).
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -20,6 +20,19 @@ service cloud.firestore {
                     && request.resource.data.nickname.size() <= 24;
       allow update: if request.auth != null && request.auth.uid == uid;
       allow delete: if false;
+
+      // /users/{uid}/friends/{friendUid}
+      // Subcollezione amici. Una relazione di amicizia consiste in DUE doc
+      // speculari: /users/A/friends/B e /users/B/friends/A. Entrambe le parti
+      // possono scrivere su entrambi i lati (necessario per il pattern
+      // simmetrico via writeBatch). Lettura riservata al proprietario della
+      // subcollezione: il tuo elenco amici e' privato.
+      match /friends/{friendUid} {
+        allow read: if request.auth != null && request.auth.uid == uid;
+        allow create, update, delete:
+          if request.auth != null
+             && (request.auth.uid == uid || request.auth.uid == friendUid);
+      }
     }
 
     // /nicknames/{nicknameLowercased}

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -87,6 +87,11 @@ export const routes: Routes = [
     canActivate: [onboardedGuard],
     loadComponent: () => import('./features/search/search').then((m) => m.Search),
   },
+  {
+    path: 'friends',
+    canActivate: [onboardedGuard],
+    loadComponent: () => import('./features/friends/friends').then((m) => m.Friends),
+  },
 
   {
     path: 'leaderboard',

--- a/src/app/core/firebase/friends.service.ts
+++ b/src/app/core/firebase/friends.service.ts
@@ -1,0 +1,218 @@
+import { Injectable, inject } from '@angular/core';
+import {
+  Firestore,
+  collection,
+  deleteDoc,
+  doc,
+  getDoc,
+  getDocs,
+  getFirestore,
+  serverTimestamp,
+  setDoc,
+  writeBatch,
+} from 'firebase/firestore/lite';
+import { ensureFirebaseApp } from './firebase';
+import { AuthService } from './auth.service';
+import { NicknameService } from './nickname.service';
+
+/**
+ * Stato di un'amicizia dal punto di vista del titolare della subcollezione.
+ *  - 'pending-sent': ho mandato una richiesta a `friendUid`, in attesa che accetti
+ *  - 'pending-received': `friendUid` mi ha mandato una richiesta, posso accettare/rifiutare
+ *  - 'accepted': siamo amici
+ */
+export type FriendStatus = 'pending-sent' | 'pending-received' | 'accepted';
+
+export interface FriendEntry {
+  /** UID dell'altro utente. */
+  uid: string;
+  /** Nickname dell'altro (snapshot al momento della richiesta; non si aggiorna). */
+  nickname: string;
+  /** Stato corrente della relazione. */
+  status: FriendStatus;
+  /** Timestamp di quando e' arrivata/inviata la richiesta. */
+  addedAt: unknown;
+}
+
+/**
+ * Gestione amicizie mutuali via subcollezione `/users/{uid}/friends/{friendUid}`.
+ *
+ * Pattern: per ogni relazione esistono SEMPRE due doc speculari, uno nella
+ * subcollezione di A e uno in quella di B. Quando A invita B, scriviamo:
+ *   /users/A/friends/B = { status: 'pending-sent',    nickname: 'B-nick', addedAt }
+ *   /users/B/friends/A = { status: 'pending-received', nickname: 'A-nick', addedAt }
+ *
+ * Le scritture sono atomiche via `writeBatch` (cosi' non resta mai una meta'
+ * orfana se la rete cade a meta'). Le regole Firestore permettono a entrambe
+ * le parti di scrivere su entrambi i lati della relazione (uid == request.auth
+ * o friendUid == request.auth).
+ *
+ * Niente real-time: le query sono lazy, riarmate dai chiamanti al cambio rotta.
+ */
+@Injectable({ providedIn: 'root' })
+export class FriendsService {
+  private readonly auth = inject(AuthService);
+  private readonly nicknameSvc = inject(NicknameService);
+  private readonly db: Firestore | null;
+
+  constructor() {
+    const app = ensureFirebaseApp();
+    this.db = app ? getFirestore(app) : null;
+  }
+
+  /** True se Firebase e' configurato. */
+  get enabled(): boolean {
+    return this.db !== null;
+  }
+
+  /** UID dell'utente loggato corrente, o null se anonimo / non caricato. */
+  private myUid(): string | null {
+    const u = this.auth.user();
+    return u && u !== 'loading' ? u.uid : null;
+  }
+
+  /**
+   * Manda una richiesta di amicizia a `friendUid`. Idempotente: se la
+   * relazione esiste gia' (in qualunque stato), no-op.
+   *
+   * Per evitare di leggere un nickname esterno via cross-user query, l'utente
+   * chiamante passa il nickname dell'altro (lo conosciamo perche' siamo sulla
+   * sua pagina pubblica quando clicchiamo "Aggiungi amico").
+   */
+  async sendRequest(
+    friendUid: string,
+    friendNickname: string,
+    myNickname: string,
+  ): Promise<'sent' | 'already' | 'self'> {
+    if (!this.db) throw new Error('Firebase not configured');
+    const me = this.myUid();
+    if (!me) throw new Error('Not authenticated');
+    if (me === friendUid) return 'self';
+
+    const myRef = doc(this.db, 'users', me, 'friends', friendUid);
+    const theirRef = doc(this.db, 'users', friendUid, 'friends', me);
+    const mySnap = await getDoc(myRef);
+    if (mySnap.exists()) return 'already';
+
+    const batch = writeBatch(this.db);
+    batch.set(myRef, {
+      status: 'pending-sent',
+      nickname: friendNickname,
+      addedAt: serverTimestamp(),
+    });
+    batch.set(theirRef, {
+      status: 'pending-received',
+      nickname: myNickname,
+      addedAt: serverTimestamp(),
+    });
+    await batch.commit();
+    return 'sent';
+  }
+
+  /**
+   * Accetta una richiesta ricevuta da `friendUid`. Aggiorna a 'accepted' su
+   * entrambi i lati. Falla se la richiesta non esiste o non e' nello stato
+   * 'pending-received' dal lato dell'utente.
+   */
+  async accept(friendUid: string): Promise<void> {
+    if (!this.db) throw new Error('Firebase not configured');
+    const me = this.myUid();
+    if (!me) throw new Error('Not authenticated');
+    const batch = writeBatch(this.db);
+    batch.update(doc(this.db, 'users', me, 'friends', friendUid), {
+      status: 'accepted',
+    });
+    batch.update(doc(this.db, 'users', friendUid, 'friends', me), {
+      status: 'accepted',
+    });
+    await batch.commit();
+  }
+
+  /**
+   * Rifiuta una richiesta ricevuta da `friendUid` (cancella entrambi i lati).
+   * Stesso effetto di `remove` ma semanticamente distinto per chiarire il
+   * caso d'uso. Sicuro chiamare anche se una delle due meta' e' gia' sparita.
+   */
+  async decline(friendUid: string): Promise<void> {
+    await this.removePair(friendUid);
+  }
+
+  /** Rimuove un'amicizia o annulla una richiesta inviata. Cancella entrambi i lati. */
+  async remove(friendUid: string): Promise<void> {
+    await this.removePair(friendUid);
+  }
+
+  private async removePair(friendUid: string): Promise<void> {
+    if (!this.db) throw new Error('Firebase not configured');
+    const me = this.myUid();
+    if (!me) throw new Error('Not authenticated');
+    const myRef = doc(this.db, 'users', me, 'friends', friendUid);
+    const theirRef = doc(this.db, 'users', friendUid, 'friends', me);
+    // Le delete sono tolleranti a "doc inesistente", quindi non serve
+    // controllo preliminare.
+    const batch = writeBatch(this.db);
+    batch.delete(myRef);
+    batch.delete(theirRef);
+    await batch.commit();
+  }
+
+  /** Tutte le relazioni dell'utente loggato (accettate + pending). */
+  async listAll(): Promise<FriendEntry[]> {
+    if (!this.db) return [];
+    const me = this.myUid();
+    if (!me) return [];
+    const ref = collection(this.db, 'users', me, 'friends');
+    const snap = await getDocs(ref);
+    const out: FriendEntry[] = [];
+    snap.forEach((d) => {
+      const data = d.data();
+      out.push({
+        uid: d.id,
+        nickname: typeof data['nickname'] === 'string' ? (data['nickname'] as string) : '',
+        status: data['status'] as FriendStatus,
+        addedAt: data['addedAt'],
+      });
+    });
+    return out;
+  }
+
+  /** Filtro su `listAll` per le sole relazioni accettate. */
+  async listFriends(): Promise<FriendEntry[]> {
+    return (await this.listAll()).filter((f) => f.status === 'accepted');
+  }
+
+  /** Filtro su `listAll` per le sole richieste in arrivo da accettare. */
+  async listIncomingRequests(): Promise<FriendEntry[]> {
+    return (await this.listAll()).filter((f) => f.status === 'pending-received');
+  }
+
+  /** Filtro per le richieste inviate ancora in attesa. */
+  async listOutgoingRequests(): Promise<FriendEntry[]> {
+    return (await this.listAll()).filter((f) => f.status === 'pending-sent');
+  }
+
+  /** Stato della relazione con `friendUid`, o null se non esiste. */
+  async statusWith(friendUid: string): Promise<FriendStatus | null> {
+    if (!this.db) return null;
+    const me = this.myUid();
+    if (!me) return null;
+    const ref = doc(this.db, 'users', me, 'friends', friendUid);
+    const snap = await getDoc(ref);
+    if (!snap.exists()) return null;
+    return (snap.data()?.['status'] as FriendStatus) ?? null;
+  }
+
+  /**
+   * Risolve il nickname di un altro utente in uid (servizio di comodo via
+   * NicknameService) e manda la richiesta. Usato dal bottone "Aggiungi
+   * amico" sulla pagina del profilo pubblico, dove abbiamo solo il nickname.
+   */
+  async sendRequestByNickname(
+    friendNickname: string,
+    myNickname: string,
+  ): Promise<'sent' | 'already' | 'self' | 'not-found'> {
+    const userDoc = await this.nicknameSvc.getUserByNickname(friendNickname);
+    if (!userDoc) return 'not-found';
+    return await this.sendRequest(userDoc.uid, friendNickname, myNickname);
+  }
+}

--- a/src/app/features/friends/friends.css
+++ b/src/app/features/friends/friends.css
@@ -1,0 +1,163 @@
+.fr-page {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding-bottom: 32px;
+}
+
+.fr-anon {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 16px;
+  padding: 60px 16px 24px;
+}
+.fr-anon p {
+  max-width: 320px;
+  font-size: 14px;
+  line-height: 1.5;
+  margin: 0;
+}
+
+/* Tabs Amici/Richieste: riusa .seg globale, ma il tab Richieste puo' avere
+   una pillola col conteggio (badge ambra). */
+.fr-tabs {
+  margin-top: 4px;
+}
+.fr-tab-with-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+}
+.fr-tab-badge {
+  display: inline-grid;
+  place-items: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  border-radius: 999px;
+  background: var(--accent);
+  color: var(--accent-contrast);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.fr-loading {
+  display: flex;
+  justify-content: center;
+  padding: 32px 0;
+}
+.fr-spinner {
+  width: 24px;
+  height: 24px;
+  border: 2px solid var(--surface-2);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: fr-spin 0.7s linear infinite;
+}
+@keyframes fr-spin {
+  to { transform: rotate(360deg); }
+}
+[data-motion="minimal"] .fr-spinner { animation: none; }
+
+.fr-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 12px;
+  padding: 40px 16px 24px;
+}
+.fr-empty-glyph {
+  font-family: var(--font-glyph);
+  font-size: 56px;
+  color: var(--accent);
+  opacity: 0.5;
+  line-height: 1;
+}
+.fr-empty p {
+  max-width: 320px;
+  font-size: 14px;
+  line-height: 1.5;
+  margin: 0;
+}
+
+.fr-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+/* Riga di una persona: parte cliccabile (avatar + nick) a sinistra che porta
+   al profilo pubblico, azioni (Rimuovi / Accetta / Rifiuta) a destra. */
+.fr-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px 8px 8px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  transition: background var(--hover-dur) ease;
+}
+.fr-row-main {
+  appearance: none;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex: 1;
+  min-width: 0;
+  padding: 4px 6px;
+  background: transparent;
+  border: 0;
+  color: var(--text);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  border-radius: 8px;
+  transition: background var(--hover-dur) ease;
+}
+.fr-row-main:hover {
+  background: var(--surface-2);
+}
+.fr-avatar {
+  flex-shrink: 0;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: var(--accent);
+  color: var(--accent-contrast);
+  display: grid;
+  place-items: center;
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 13px;
+  line-height: 1;
+}
+.fr-nick {
+  font-size: 14px;
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.fr-row-actions {
+  display: flex;
+  gap: 6px;
+  flex-shrink: 0;
+}
+.fr-action-btn {
+  height: 32px;
+  font-size: 12px;
+  padding: 0 12px;
+}
+.fr-row-action {
+  height: 32px;
+  font-size: 12px;
+  padding: 0 12px;
+}

--- a/src/app/features/friends/friends.html
+++ b/src/app/features/friends/friends.html
@@ -1,0 +1,111 @@
+<div class="app-shell">
+  <app-bar [canBack]="true"
+           [title]="i18n.lang() === 'it' ? 'Amici' : 'Friends'"
+           (back)="goBack()"
+           (goHome)="goHome()" />
+
+  <div class="page fr-page">
+    @if (notLogged()) {
+      <div class="fr-anon">
+        <p class="muted">
+          {{ i18n.lang() === 'it'
+            ? 'Accedi al tuo profilo per aggiungere amici e ricevere richieste.'
+            : 'Sign in to add friends and receive requests.' }}
+        </p>
+        <button class="btn btn-primary" type="button" (click)="goLogin()">
+          {{ i18n.t('login') }}
+        </button>
+      </div>
+    } @else {
+      <!-- Switch tab Amici / Richieste con badge sul numero richieste. -->
+      <div class="seg fr-tabs">
+        <button type="button" class="seg-btn"
+                [class.is-active]="tab() === 'friends'"
+                (click)="setTab('friends')">
+          {{ i18n.lang() === 'it' ? 'Amici' : 'Friends' }}
+        </button>
+        <button type="button" class="seg-btn fr-tab-with-badge"
+                [class.is-active]="tab() === 'requests'"
+                (click)="setTab('requests')">
+          {{ i18n.lang() === 'it' ? 'Richieste' : 'Requests' }}
+          @if (requests().length > 0) {
+            <span class="fr-tab-badge">{{ requests().length }}</span>
+          }
+        </button>
+      </div>
+
+      @if (loading()) {
+        <div class="fr-loading">
+          <span class="fr-spinner" aria-label="loading"></span>
+        </div>
+      } @else if (tab() === 'friends') {
+        @if (friends().length === 0) {
+          <div class="fr-empty">
+            <span class="fr-empty-glyph" aria-hidden="true">友</span>
+            <p class="muted">
+              {{ i18n.lang() === 'it'
+                ? 'Niente amici per ora. Cerca qualcuno per inviare la prima richiesta.'
+                : 'No friends yet. Search for someone to send your first request.' }}
+            </p>
+            <button class="btn btn-ghost" type="button" (click)="goSearch()">
+              {{ i18n.lang() === 'it' ? 'Cerca utenti' : 'Find users' }}
+            </button>
+          </div>
+        } @else {
+          <div class="fr-list">
+            @for (f of friends(); track f.uid) {
+              <div class="fr-row">
+                <button class="fr-row-main" type="button" (click)="openProfile(f.nickname)">
+                  <span class="fr-avatar">{{ (f.nickname || '?').charAt(0).toUpperCase() }}</span>
+                  <span class="fr-nick">{{ f.nickname }}</span>
+                </button>
+                <button class="nav-btn fr-row-action"
+                        type="button"
+                        [disabled]="pendingAction() === f.uid"
+                        (click)="remove(f.uid)">
+                  {{ i18n.lang() === 'it' ? 'Rimuovi' : 'Remove' }}
+                </button>
+              </div>
+            }
+          </div>
+        }
+      } @else {
+        @if (requests().length === 0) {
+          <div class="fr-empty">
+            <span class="fr-empty-glyph" aria-hidden="true">∅</span>
+            <p class="muted">
+              {{ i18n.lang() === 'it'
+                ? 'Nessuna richiesta in attesa.'
+                : 'No pending requests.' }}
+            </p>
+          </div>
+        } @else {
+          <div class="fr-list">
+            @for (r of requests(); track r.uid) {
+              <div class="fr-row">
+                <button class="fr-row-main" type="button" (click)="openProfile(r.nickname)">
+                  <span class="fr-avatar">{{ (r.nickname || '?').charAt(0).toUpperCase() }}</span>
+                  <span class="fr-nick">{{ r.nickname }}</span>
+                </button>
+                <div class="fr-row-actions">
+                  <button class="btn btn-primary fr-action-btn"
+                          type="button"
+                          [disabled]="pendingAction() === r.uid"
+                          (click)="accept(r.uid)">
+                    {{ i18n.lang() === 'it' ? 'Accetta' : 'Accept' }}
+                  </button>
+                  <button class="nav-btn fr-action-btn"
+                          type="button"
+                          [disabled]="pendingAction() === r.uid"
+                          (click)="decline(r.uid)">
+                    {{ i18n.lang() === 'it' ? 'Rifiuta' : 'Decline' }}
+                  </button>
+                </div>
+              </div>
+            }
+          </div>
+        }
+      }
+    }
+  </div>
+</div>

--- a/src/app/features/friends/friends.ts
+++ b/src/app/features/friends/friends.ts
@@ -1,0 +1,130 @@
+import { ChangeDetectionStrategy, Component, computed, effect, inject, signal } from '@angular/core';
+import { Location } from '@angular/common';
+import { Router } from '@angular/router';
+import { I18nService } from '../../core/i18n/i18n.service';
+import { AppStateService } from '../../core/state/app-state.service';
+import { FriendEntry, FriendsService } from '../../core/firebase/friends.service';
+import { AppBar } from '../../shared/app-bar';
+
+type Tab = 'friends' | 'requests';
+
+/**
+ * Pagina /amici: due tab "Amici" e "Richieste". Le liste sono lazy, refetch
+ * ad ogni cambio tab e ogni volta che si torna sulla pagina. Niente
+ * real-time: serve aprire/cambiare rotta per vedere richieste nuove.
+ */
+@Component({
+  selector: 'app-friends',
+  imports: [AppBar],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './friends.html',
+  styleUrl: './friends.css',
+})
+export class Friends {
+  private readonly router = inject(Router);
+  private readonly location = inject(Location);
+  protected readonly i18n = inject(I18nService);
+  protected readonly appState = inject(AppStateService);
+  private readonly fSvc = inject(FriendsService);
+
+  protected readonly tab = signal<Tab>('friends');
+  protected readonly loading = signal(true);
+  protected readonly friends = signal<FriendEntry[]>([]);
+  protected readonly requests = signal<FriendEntry[]>([]);
+  protected readonly pendingAction = signal<string | null>(null);
+
+  /** True se l'utente non e' loggato: la pagina mostra CTA "Accedi". */
+  protected readonly notLogged = computed(
+    () => !this.appState.state().account,
+  );
+
+  constructor() {
+    // Ricarica liste ogni volta che il tab cambia.
+    effect(() => {
+      this.tab();
+      if (this.notLogged()) {
+        this.loading.set(false);
+        return;
+      }
+      void this.refetch();
+    });
+  }
+
+  private async refetch(): Promise<void> {
+    this.loading.set(true);
+    try {
+      const all = await this.fSvc.listAll();
+      this.friends.set(all.filter((f) => f.status === 'accepted'));
+      this.requests.set(all.filter((f) => f.status === 'pending-received'));
+    } catch (e) {
+      console.warn('[friends] refetch error:', e);
+    } finally {
+      this.loading.set(false);
+    }
+  }
+
+  protected setTab(t: Tab): void {
+    this.tab.set(t);
+  }
+
+  protected async accept(uid: string): Promise<void> {
+    this.pendingAction.set(uid);
+    try {
+      await this.fSvc.accept(uid);
+      await this.refetch();
+    } catch (e) {
+      console.warn('[friends] accept error:', e);
+    } finally {
+      this.pendingAction.set(null);
+    }
+  }
+
+  protected async decline(uid: string): Promise<void> {
+    this.pendingAction.set(uid);
+    try {
+      await this.fSvc.decline(uid);
+      await this.refetch();
+    } catch (e) {
+      console.warn('[friends] decline error:', e);
+    } finally {
+      this.pendingAction.set(null);
+    }
+  }
+
+  protected async remove(uid: string): Promise<void> {
+    if (typeof window !== 'undefined') {
+      const msg =
+        this.i18n.lang() === 'it'
+          ? 'Vuoi davvero rimuovere questo amico?'
+          : 'Really remove this friend?';
+      if (!window.confirm(msg)) return;
+    }
+    this.pendingAction.set(uid);
+    try {
+      await this.fSvc.remove(uid);
+      await this.refetch();
+    } catch (e) {
+      console.warn('[friends] remove error:', e);
+    } finally {
+      this.pendingAction.set(null);
+    }
+  }
+
+  protected openProfile(nickname: string): void {
+    if (!nickname) return;
+    this.router.navigate(['/u', nickname]);
+  }
+
+  protected goLogin(): void {
+    this.router.navigate(['/login']);
+  }
+  protected goSearch(): void {
+    this.router.navigate(['/search']);
+  }
+  protected goBack(): void {
+    this.location.back();
+  }
+  protected goHome(): void {
+    this.router.navigate(['/home']);
+  }
+}

--- a/src/app/features/home/home.css
+++ b/src/app/features/home/home.css
@@ -258,3 +258,27 @@
 .account-menu-item.is-danger:hover {
   background: rgba(251, 113, 133, 0.08);
 }
+
+/* Voce "Amici" con pillino contatore richieste in arrivo. Layout: label
+   a destra (gia' per text-align: right), badge accent a sinistra (flex
+   row-reverse via gap su justify-end). */
+.account-menu-friends {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+}
+.account-menu-badge {
+  display: inline-grid;
+  place-items: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  border-radius: 999px;
+  background: var(--accent);
+  color: var(--accent-contrast);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1;
+}

--- a/src/app/features/home/home.html
+++ b/src/app/features/home/home.html
@@ -26,6 +26,13 @@
                     (click)="closeAccountMenu(); goProfile()">
               {{ i18n.t('profile') }}
             </button>
+            <button type="button" class="account-menu-item account-menu-friends" role="menuitem"
+                    (click)="closeAccountMenu(); goFriends()">
+              <span>{{ i18n.lang() === 'it' ? 'Amici' : 'Friends' }}</span>
+              @if (pendingFriendRequests() > 0) {
+                <span class="account-menu-badge">{{ pendingFriendRequests() }}</span>
+              }
+            </button>
             <button type="button" class="account-menu-item" role="menuitem"
                     (click)="closeAccountMenu(); goSearch()">
               {{ i18n.lang() === 'it' ? 'Cerca utenti' : 'Find users' }}

--- a/src/app/features/home/home.ts
+++ b/src/app/features/home/home.ts
@@ -1,8 +1,9 @@
-import { ChangeDetectionStrategy, Component, HostListener, computed, inject, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, HostListener, computed, effect, inject, signal } from '@angular/core';
 import { Router } from '@angular/router';
 import { I18nService } from '../../core/i18n/i18n.service';
 import { AppStateService } from '../../core/state/app-state.service';
 import { AuthService } from '../../core/firebase/auth.service';
+import { FriendsService } from '../../core/firebase/friends.service';
 import { ALL_SCRIPT_IDS } from '../../core/data/scripts';
 import { buildQuestion, mulberry32, seedFromDate } from '../../core/data/quiz';
 import { computeBadges } from '../../core/data/badges';
@@ -27,8 +28,23 @@ export class Home {
   protected readonly i18n = inject(I18nService);
   protected readonly appState = inject(AppStateService);
   private readonly authSvc = inject(AuthService);
+  private readonly friendsSvc = inject(FriendsService);
 
   protected readonly state = this.appState.state;
+
+  /** Numero di richieste amicizia in arrivo, mostrato come pillino nel menu
+   *  account. Refetchato lazy: ogni volta che la home si carica (componente
+   *  ricreato dal router) e ad ogni cambio di uid dell'account loggato. */
+  protected readonly pendingFriendRequests = signal(0);
+
+  private readonly _refreshFriendsOnAuth = effect(() => {
+    const uid = this.state().account?.uid ?? null;
+    if (uid) {
+      void this.refreshFriendRequests();
+    } else {
+      this.pendingFriendRequests.set(0);
+    }
+  });
 
   /** Apertura del menu account (popover sotto l'icona in alto a destra). */
   protected readonly accountMenuOpen = signal(false);
@@ -177,6 +193,26 @@ export class Home {
 
   protected goSearch(): void {
     this.router.navigate(['/search']);
+  }
+
+  protected goFriends(): void {
+    this.router.navigate(['/friends']);
+  }
+
+  /** Rileggi il conteggio richieste in arrivo. Chiamata all'apertura della
+   *  home (via effect) e quando si torna sulla home (la component si ricrea
+   *  con router OnPush). */
+  protected async refreshFriendRequests(): Promise<void> {
+    if (!this.state().account) {
+      this.pendingFriendRequests.set(0);
+      return;
+    }
+    try {
+      const list = await this.friendsSvc.listIncomingRequests();
+      this.pendingFriendRequests.set(list.length);
+    } catch {
+      // ignore: il badge resta com'era
+    }
   }
 
   /** Toggle del popover account; chiude se aperto, apre se chiuso. Lo

--- a/src/app/features/public-profile/public-profile.css
+++ b/src/app/features/public-profile/public-profile.css
@@ -76,6 +76,19 @@
   margin: 0;
 }
 
+/* Bottone amicizia centrato sotto il nick: cambia label e stile in base allo
+   stato (nessuna relazione, richiesta inviata, richiesta da accettare, gia'
+   amici). */
+.pub-friend-bar {
+  display: flex;
+  justify-content: center;
+  margin-top: 4px;
+}
+.pub-friend-btn {
+  min-width: 200px;
+  justify-content: center;
+}
+
 .pub-stats {
   display: grid;
   grid-template-columns: 1fr 1fr;

--- a/src/app/features/public-profile/public-profile.html
+++ b/src/app/features/public-profile/public-profile.html
@@ -46,6 +46,48 @@
         }
       </div>
 
+      <!-- Bottone amicizia: stati distinti in base alla relazione corrente.
+           Visibile solo se sto guardando il profilo di qualcun altro (non il
+           mio) e sono loggato. -->
+      @if (!isSelf() && appState.state().account) {
+        <div class="pub-friend-bar">
+          @switch (friendStatus()) {
+            @case ('accepted') {
+              <button class="nav-btn pub-friend-btn"
+                      type="button"
+                      [disabled]="friendBusy()"
+                      (click)="removeFriend()">
+                ✓ {{ i18n.lang() === 'it' ? 'Siete amici' : 'Friends' }}
+              </button>
+            }
+            @case ('pending-sent') {
+              <button class="nav-btn pub-friend-btn"
+                      type="button"
+                      [disabled]="friendBusy()"
+                      (click)="cancelRequest()">
+                {{ i18n.lang() === 'it' ? 'Richiesta inviata · Annulla' : 'Request sent · Cancel' }}
+              </button>
+            }
+            @case ('pending-received') {
+              <button class="btn btn-primary pub-friend-btn"
+                      type="button"
+                      [disabled]="friendBusy()"
+                      (click)="acceptRequest()">
+                {{ i18n.lang() === 'it' ? 'Accetta richiesta' : 'Accept request' }}
+              </button>
+            }
+            @default {
+              <button class="btn btn-primary pub-friend-btn"
+                      type="button"
+                      [disabled]="friendBusy()"
+                      (click)="addFriend()">
+                + {{ i18n.lang() === 'it' ? 'Aggiungi amico' : 'Add friend' }}
+              </button>
+            }
+          }
+        </div>
+      }
+
       <!-- Stats 2x2 (best, accuracy, played, dailyStreak) -->
       <div class="pub-stats">
         <div class="stat">

--- a/src/app/features/public-profile/public-profile.ts
+++ b/src/app/features/public-profile/public-profile.ts
@@ -6,6 +6,7 @@ import { map } from 'rxjs/operators';
 import { I18nService } from '../../core/i18n/i18n.service';
 import { AppStateService } from '../../core/state/app-state.service';
 import { NicknameService } from '../../core/firebase/nickname.service';
+import { FriendStatus, FriendsService } from '../../core/firebase/friends.service';
 import { avatarById } from '../../core/data/avatars';
 import { BadgeWithProgress, computeBadges } from '../../core/data/badges';
 import { ScriptInfo, scriptById } from '../../core/data/scripts';
@@ -32,6 +33,7 @@ export class PublicProfile {
   protected readonly i18n = inject(I18nService);
   protected readonly appState = inject(AppStateService);
   private readonly nicknames = inject(NicknameService);
+  private readonly friends = inject(FriendsService);
 
   /** Param `:nickname` dalla rotta, in formato URL-encoded come arriva. */
   protected readonly nickname = toSignal(
@@ -43,6 +45,11 @@ export class PublicProfile {
   protected readonly notFound = signal(false);
   protected readonly profile = signal<PublicProfileData | null>(null);
   protected readonly copyFlash = signal(false);
+
+  /** Stato amicizia con l'utente visualizzato. null = nessuna relazione. */
+  protected readonly friendStatus = signal<FriendStatus | null>(null);
+  /** Lock per evitare doppi-click sui bottoni amicizia. */
+  protected readonly friendBusy = signal(false);
 
   protected readonly isSelf = computed(() => {
     const p = this.profile();
@@ -84,6 +91,7 @@ export class PublicProfile {
       this.loading.set(true);
       this.notFound.set(false);
       this.profile.set(null);
+      this.friendStatus.set(null);
       void this.fetch(n);
     });
   }
@@ -139,11 +147,89 @@ export class PublicProfile {
         totalBadges: allBadges.length,
         scriptStats,
       });
+      // Stato amicizia: read separata (non bloccante per il render).
+      if (this.appState.state().account && doc.uid !== this.appState.state().account?.uid) {
+        try {
+          const status = await this.friends.statusWith(doc.uid);
+          this.friendStatus.set(status);
+        } catch (e) {
+          console.warn('[public-profile] friend status error:', e);
+        }
+      }
     } catch (e) {
       console.warn('[public-profile] fetch error:', e);
       this.notFound.set(true);
     } finally {
       this.loading.set(false);
+    }
+  }
+
+  /** Azione "Aggiungi amico": manda richiesta. Aggiorna lo stato locale a
+   *  'pending-sent' senza ricaricare l'intera pagina. */
+  protected async addFriend(): Promise<void> {
+    const p = this.profile();
+    const myNick = this.appState.state().account?.nickname;
+    if (!p || !myNick || this.friendBusy()) return;
+    this.friendBusy.set(true);
+    try {
+      const r = await this.friends.sendRequest(p.uid, p.nickname, myNick);
+      if (r === 'sent') this.friendStatus.set('pending-sent');
+    } catch (e) {
+      console.warn('[public-profile] addFriend error:', e);
+    } finally {
+      this.friendBusy.set(false);
+    }
+  }
+
+  /** Annulla richiesta inviata (rimuove la pending). */
+  protected async cancelRequest(): Promise<void> {
+    const p = this.profile();
+    if (!p || this.friendBusy()) return;
+    this.friendBusy.set(true);
+    try {
+      await this.friends.remove(p.uid);
+      this.friendStatus.set(null);
+    } catch (e) {
+      console.warn('[public-profile] cancelRequest error:', e);
+    } finally {
+      this.friendBusy.set(false);
+    }
+  }
+
+  /** Accetta richiesta in arrivo (l'altro mi ha invitato, sono sul suo profilo). */
+  protected async acceptRequest(): Promise<void> {
+    const p = this.profile();
+    if (!p || this.friendBusy()) return;
+    this.friendBusy.set(true);
+    try {
+      await this.friends.accept(p.uid);
+      this.friendStatus.set('accepted');
+    } catch (e) {
+      console.warn('[public-profile] acceptRequest error:', e);
+    } finally {
+      this.friendBusy.set(false);
+    }
+  }
+
+  /** Rimuove l'amicizia (gia' accettata). */
+  protected async removeFriend(): Promise<void> {
+    const p = this.profile();
+    if (!p || this.friendBusy()) return;
+    if (typeof window !== 'undefined') {
+      const msg =
+        this.i18n.lang() === 'it'
+          ? 'Vuoi rimuovere ' + p.nickname + ' dagli amici?'
+          : 'Remove ' + p.nickname + ' from friends?';
+      if (!window.confirm(msg)) return;
+    }
+    this.friendBusy.set(true);
+    try {
+      await this.friends.remove(p.uid);
+      this.friendStatus.set(null);
+    } catch (e) {
+      console.warn('[public-profile] removeFriend error:', e);
+    } finally {
+      this.friendBusy.set(false);
     }
   }
 


### PR DESCRIPTION
Prima delle tre PR per la sezione amici. Aggiunge il sistema di amicizia mutuale: invio richiesta -> accettazione -> amici. Niente challenge ancora, viene in PR successive.

Modello dati

Subcollezione /users/{uid}/friends/{friendUid} con status pending-sent / pending-received / accepted. Una relazione = DUE doc speculari, scritti in atomico via writeBatch. Le regole Firestore consentono a entrambe le parti di scrivere su entrambi i lati. Lettura riservata al proprietario della propria subcollezione: la lista amici e' privata.

Servizio

Nuovo FriendsService in core/firebase/ con metodi: sendRequest/sendRequestByNickname (entrambe le parti vedono status pending), accept (entrambe -> accepted), decline/remove (delete batch), listAll/listFriends/listIncomingRequests/listOutgoingRequests, statusWith.

UI

- Pagina /amici nuova: due tab Amici e Richieste con badge sul conteggio. Click su una riga apre /u/nickname; bottoni di azione contestuali (Accetta/Rifiuta sulle richieste, Rimuovi sugli amici).
- Profilo pubblico /u/nickname: nuovo bottone amicizia sotto la hero, stati distinti in switch (Aggiungi amico / Richiesta inviata · Annulla / Accetta richiesta / ✓ Siete amici). Visibile solo se loggato e non e' il proprio profilo.
- Menu account in home: nuova voce Amici con pillino accent che conta le richieste in arrivo. Refetch al boot e al cambio di uid (login/logout/switch account).

Cose NON in questa PR

Confronto sulla daily con gli amici (PR 2). Sfida custom da un set di 5 glifi (PR 3). Notifiche real-time (resto su lazy: refetch al cambio rotta).

Setup richiesto una-tantum: dopo merge, lanciare npm run deploy:rules. Senza, le write sulla subcollezione friends verrebbero rifiutate.