### PR TITLE
fix(login): toggle occhio per mostrare la password + messaggio chiaro per email gia' registrata

### DIFF
--- a/src/app/features/login/login.css
+++ b/src/app/features/login/login.css
@@ -152,6 +152,41 @@
   border-color: var(--accent);
 }
 
+/* Campo password con bottone occhio in overlay a destra. L'input riserva
+   padding-right sufficiente perche' la password digitata non vada sotto al
+   bottone. Il bottone non altera il flow del form, e' position-absolute. */
+.login-pass-wrap {
+  position: relative;
+}
+.login-pass-input {
+  padding-right: 44px;
+}
+.login-pass-toggle {
+  position: absolute;
+  top: 50%;
+  right: 8px;
+  transform: translateY(-50%);
+  appearance: none;
+  background: transparent;
+  border: 0;
+  color: var(--text-mute);
+  width: 32px;
+  height: 32px;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  border-radius: 8px;
+  transition: background var(--hover-dur) ease, color var(--hover-dur) ease;
+}
+.login-pass-toggle:hover {
+  background: var(--surface-2);
+  color: var(--text);
+}
+.login-pass-toggle:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
 .login-error {
   margin: 0;
   padding: 10px 12px;

--- a/src/app/features/login/login.html
+++ b/src/app/features/login/login.html
@@ -91,17 +91,44 @@
               {{ i18n.lang() === 'it' ? 'almeno 6 caratteri' : 'at least 6 characters' }}
             </span>
           </span>
-          <input
-            type="password"
-            autocomplete="current-password"
-            class="input-field"
-            placeholder="••••••"
-            [ngModel]="password()"
-            (ngModelChange)="setPassword($event)"
-            name="password"
-            minlength="6"
-            required
-          />
+          <div class="login-pass-wrap">
+            <input
+              [type]="showPassword() ? 'text' : 'password'"
+              autocomplete="current-password"
+              class="input-field login-pass-input"
+              placeholder="••••••"
+              [ngModel]="password()"
+              (ngModelChange)="setPassword($event)"
+              name="password"
+              minlength="6"
+              required
+            />
+            <button
+              type="button"
+              class="login-pass-toggle"
+              (click)="toggleShowPassword()"
+              [attr.aria-label]="showPassword()
+                ? (i18n.lang() === 'it' ? 'Nascondi password' : 'Hide password')
+                : (i18n.lang() === 'it' ? 'Mostra password' : 'Show password')"
+              [attr.aria-pressed]="showPassword()"
+            >
+              @if (showPassword()) {
+                <!-- Occhio sbarrato: la password e' visibile, tap per nascondere. -->
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+                  <path d="M9.88 9.88a3 3 0 1 0 4.24 4.24"/>
+                  <path d="M10.73 5.08A10.43 10.43 0 0 1 12 5c7 0 10 7 10 7a13.16 13.16 0 0 1-1.67 2.68"/>
+                  <path d="M6.61 6.61A13.526 13.526 0 0 0 2 12s3 7 10 7a9.74 9.74 0 0 0 5.39-1.61"/>
+                  <line x1="2" y1="2" x2="22" y2="22"/>
+                </svg>
+              } @else {
+                <!-- Occhio aperto: la password e' nascosta, tap per mostrare. -->
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+                  <path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7z"/>
+                  <circle cx="12" cy="12" r="3"/>
+                </svg>
+              }
+            </button>
+          </div>
         </label>
 
         @if (error(); as e) {

--- a/src/app/features/login/login.ts
+++ b/src/app/features/login/login.ts
@@ -24,8 +24,13 @@ export class Login {
 
   protected readonly email = signal('');
   protected readonly password = signal('');
+  protected readonly showPassword = signal(false);
   protected readonly busy = signal(false);
   protected readonly error = signal<string | null>(null);
+
+  protected toggleShowPassword(): void {
+    this.showPassword.update((v) => !v);
+  }
 
   /** Se siamo gia' autenticati: tornare al rendering qui dentro significa che
    *  ci siamo arrivati dal redirect Google (o che eravamo gia' loggati e
@@ -111,9 +116,14 @@ export class Login {
           await this.auth.signUpEmail(email, password);
         } catch (signUpErr: unknown) {
           // Se signUp fallisce con "email in uso", l'account esiste e la
-          // password e' sbagliata: rilanciamo come "credenziali errate".
+          // password e' sbagliata. Lanciamo un codice custom cosi' il
+          // messaggio user-facing dice "account gia' esistente" invece
+          // del generico "credenziali errate" che confonde chi pensa di
+          // stare creando un nuovo account.
           const upCode = (signUpErr as { code?: string })?.code ?? '';
-          if (upCode === 'auth/email-already-in-use') throw signInErr;
+          if (upCode === 'auth/email-already-in-use') {
+            throw { code: 'gtc/account-exists-wrong-password' };
+          }
           throw signUpErr;
         }
       }
@@ -180,6 +190,10 @@ export class Login {
         return isIt
           ? 'Email o password non corrette.'
           : 'Email or password is incorrect.';
+      case 'gtc/account-exists-wrong-password':
+        return isIt
+          ? 'Esiste gia\' un account con questa email, ma la password non corrisponde. Se non ricordi la password, prova con un\'email diversa.'
+          : 'An account with this email already exists, but the password doesn\'t match. If you don\'t remember it, try a different email.';
       case 'auth/too-many-requests':
         return isIt
           ? 'Troppi tentativi in poco tempo: riprova fra qualche minuto.'


### PR DESCRIPTION
Due piccoli fix sulla pagina /login.

Toggle visibilita' password

Bottone occhio a destra del campo password (in overlay assoluto, non altera il layout del form). Click sull'occhio mostra il testo in chiaro; click sull'occhio sbarrato lo riporta a pallini. SVG inline a 18px, focus-visible per accessibilita' da tastiera. Stato in showPassword signal.

Messaggio errore piu' chiaro per email gia' registrata

Prima quando provavi a creare account con un'email gia' usata, vedevi 'Email o password non corrette' (perche' nel flow unificato signIn fallisce, signUp fallisce con email-already-in-use, e ritornavamo l'errore originale di signIn). Confondeva chi si stava registrando: 'Non sto provando a fare login, sto creando un account!'.

Ora quando signUp risponde email-already-in-use, lanciamo un codice custom 'gtc/account-exists-wrong-password' che translateError mappa a 'Esiste gia\' un account con questa email, ma la password non corrisponde. Se non ricordi la password, prova con un\'email diversa.' Cosi' chi tenta una signup capisce subito che il problema e' un account preesistente, non una credenziale sbagliata.

Niente cambia se l'email NON e' registrata: il flow signIn -> signUp continua a creare un nuovo account come prima, senza messaggi di errore.