### PR TITLE
feat(profile): record sfide tra amici nel profilo

### DIFF
--- a/src/app/core/firebase/challenges.service.ts
+++ b/src/app/core/firebase/challenges.service.ts
@@ -47,6 +47,13 @@ export interface ChallengeDoc {
   completedAt: unknown;
 }
 
+export interface ChallengeStats {
+  won: number;
+  lost: number;
+  draw: number;
+  total: number;
+}
+
 const TOTAL_Q = 5;
 
 /**
@@ -180,6 +187,36 @@ export class ChallengesService {
   async countPendingIncoming(): Promise<number> {
     const all = await this.listIncoming();
     return all.filter((c) => c.status === 'pending').length;
+  }
+
+  /**
+   * Aggregato di tutte le sfide completate dell'utente loggato: quante ha
+   * vinto, perso, pareggiato. Usato in /profile per mostrare un record
+   * sintetico delle sfide tra amici. Conta come "vittoria" se il mio score
+   * supera quello dell'avversario, "sconfitta" se inferiore, "pareggio" se
+   * uguali (incluse le 5-5 e le 0-0).
+   *
+   * Costo: 2 query Firestore (incoming + outgoing). Aggregato lato client.
+   */
+  async getChallengeStats(): Promise<ChallengeStats> {
+    if (!this.db) return { won: 0, lost: 0, draw: 0, total: 0 };
+    const me = this.appState.state().account?.uid;
+    if (!me) return { won: 0, lost: 0, draw: 0, total: 0 };
+    const [inc, out] = await Promise.all([this.listIncoming(), this.listOutgoing()]);
+    let won = 0;
+    let lost = 0;
+    let draw = 0;
+    const completed = [...inc, ...out].filter(
+      (c) => c.status === 'completed' && typeof c.toScore === 'number',
+    );
+    for (const c of completed) {
+      const meScore = me === c.to ? (c.toScore ?? 0) : c.fromScore;
+      const them = me === c.to ? c.fromScore : (c.toScore ?? 0);
+      if (meScore > them) won++;
+      else if (meScore < them) lost++;
+      else draw++;
+    }
+    return { won, lost, draw, total: won + lost + draw };
   }
 
   /** Risposta del destinatario alla sfida: setta toScore e segna completed. */

--- a/src/app/features/profile/profile.css
+++ b/src/app/features/profile/profile.css
@@ -437,3 +437,40 @@
   margin-top: 4px;
   line-height: 1.4;
 }
+
+/* Card "Sfide tra amici" cliccabile sotto le stats principali. Tre numeri
+   (vinte/perse/pari) con accenti di colore distinti. */
+.profile-challenge-card {
+  appearance: none;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  width: 100%;
+  margin-top: 12px;
+  padding: 14px 16px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  color: var(--text);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    background var(--hover-dur) ease,
+    border-color var(--hover-dur) ease;
+}
+.profile-challenge-card:hover {
+  background: var(--surface-2);
+  border-color: var(--border-strong);
+}
+.profile-challenge-eyebrow {
+  margin: 0;
+}
+.profile-challenge-stats {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 8px;
+}
+.profile-challenge-stats .v[data-tone='win'] { color: var(--ok); }
+.profile-challenge-stats .v[data-tone='lose'] { color: var(--bad); }
+.profile-challenge-stats .v[data-tone='draw'] { color: var(--text-dim); }

--- a/src/app/features/profile/profile.html
+++ b/src/app/features/profile/profile.html
@@ -146,6 +146,35 @@
       </div>
     </div>
 
+    <!-- Record sfide tra amici: visibile solo se loggato e con almeno una sfida
+         completata. Tap apre /sfide. -->
+    @if (challengeStats(); as cs) {
+      @if (cs.total > 0) {
+        <button type="button"
+                class="profile-challenge-card"
+                (click)="goChallenges()"
+                [attr.aria-label]="i18n.lang() === 'it' ? 'Vai alle sfide' : 'Go to challenges'">
+          <span class="eyebrow profile-challenge-eyebrow">
+            {{ i18n.lang() === 'it' ? 'SFIDE TRA AMICI' : 'FRIEND CHALLENGES' }}
+          </span>
+          <div class="profile-challenge-stats">
+            <div class="stat">
+              <span class="v" data-tone="win">{{ cs.won }}</span>
+              <span class="l">{{ i18n.lang() === 'it' ? 'Vinte' : 'Won' }}</span>
+            </div>
+            <div class="stat">
+              <span class="v" data-tone="lose">{{ cs.lost }}</span>
+              <span class="l">{{ i18n.lang() === 'it' ? 'Perse' : 'Lost' }}</span>
+            </div>
+            <div class="stat">
+              <span class="v" data-tone="draw">{{ cs.draw }}</span>
+              <span class="l">{{ i18n.lang() === 'it' ? 'Pari' : 'Tied' }}</span>
+            </div>
+          </div>
+        </button>
+      }
+    }
+
     <div class="divider"></div>
 
     <h3 class="h3 section-h">

--- a/src/app/features/profile/profile.ts
+++ b/src/app/features/profile/profile.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, HostListener, computed, inject, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, HostListener, computed, effect, inject, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { Location } from '@angular/common';
 import { Router } from '@angular/router';
@@ -6,6 +6,7 @@ import { I18nService } from '../../core/i18n/i18n.service';
 import { AppStateService } from '../../core/state/app-state.service';
 import { AuthService } from '../../core/firebase/auth.service';
 import { NicknameService } from '../../core/firebase/nickname.service';
+import { ChallengeStats, ChallengesService } from '../../core/firebase/challenges.service';
 import { AVATARS, avatarById } from '../../core/data/avatars';
 import { scriptById } from '../../core/data/scripts';
 import { computeBadges } from '../../core/data/badges';
@@ -28,9 +29,36 @@ export class Profile {
   protected readonly appState = inject(AppStateService);
   private readonly authSvc = inject(AuthService);
   private readonly nicknames = inject(NicknameService);
+  private readonly challengesSvc = inject(ChallengesService);
 
   protected readonly state = this.appState.state;
   protected readonly avatars = AVATARS;
+
+  /** Record sfide tra amici (vinte/perse/pari), caricato lazy quando si apre
+   *  la pagina e l'utente e' loggato. Resta `null` finche' non e' pronto. */
+  protected readonly challengeStats = signal<ChallengeStats | null>(null);
+
+  private readonly _loadChallengeStats = effect(() => {
+    const uid = this.state().account?.uid ?? null;
+    if (!uid) {
+      this.challengeStats.set(null);
+      return;
+    }
+    void this.refreshChallengeStats();
+  });
+
+  private async refreshChallengeStats(): Promise<void> {
+    try {
+      const s = await this.challengesSvc.getChallengeStats();
+      this.challengeStats.set(s);
+    } catch (e) {
+      console.warn('[profile] challenge stats error:', e);
+    }
+  }
+
+  protected goChallenges(): void {
+    this.router.navigate(['/sfide']);
+  }
 
   protected readonly account = computed(() => this.state().account);
   protected readonly currentAvatar = computed(() => avatarById(this.account()?.avatar));


### PR DESCRIPTION
Aggiunge una piccola sezione al /profile privato: subito sotto le stats contestuali (streak/precisione/partite), una card con il record sulle sfide custom 1-vs-1. Tre numeri: Vinte (verde), Perse (rosso), Pari (grigio). Tap apre /sfide.

Visibile solo se loggato e con almeno una sfida completata, cosi' chi non ha ancora giocato a sfide non si trova una sezione vuota.

Tecnica

Nuovo metodo `getChallengeStats()` su ChallengesService che riusa listIncoming + listOutgoing, filtra completed, e somma won/lost/draw lato client. Costo: 2 query Firestore al caricamento del profilo. Aggregato lato client, non un counter persistito, perche' il dato cambia raramente e questa pagina non e' una hot-path.

Niente nuove rules Firestore, niente schema changes. Indipendente dalla #68 (docs) e dalle altre due PR in arrivo.