### PR TITLE
feat(public-profile): daily di oggi + confronto col tuo

### DIFF
--- a/src/app/features/public-profile/public-profile.css
+++ b/src/app/features/public-profile/public-profile.css
@@ -237,3 +237,67 @@
   font-size: 12px;
   padding: 0 12px;
 }
+
+/* Card "Daily oggi" sotto le stats: visibile solo sui profili altrui quando
+   l'utente ha completato la daily del giorno. Confronto a due se anche io
+   l'ho fatta, "ha fatto X/5" altrimenti. */
+.pub-daily-card {
+  margin-top: 14px;
+  padding: 12px 14px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.pub-daily-eyebrow {
+  color: var(--warm);
+}
+.pub-daily-solo {
+  margin: 0;
+  font-size: 14px;
+  color: var(--text-dim);
+  line-height: 1.5;
+}
+.pub-daily-solo strong {
+  color: var(--accent);
+  font-weight: 600;
+}
+.pub-daily-vs {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: 8px;
+  align-items: center;
+}
+.pub-daily-side {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  align-items: center;
+}
+.pub-daily-name {
+  font-size: 12px;
+  color: var(--text-dim);
+  font-weight: 500;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.pub-daily-score {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 22px;
+  line-height: 1;
+  color: var(--text);
+}
+.pub-daily-winner .pub-daily-score {
+  color: var(--accent);
+}
+.pub-daily-vs-sep {
+  font-size: 11px;
+  color: var(--text-mute);
+  font-weight: 600;
+  letter-spacing: 0.06em;
+}

--- a/src/app/features/public-profile/public-profile.html
+++ b/src/app/features/public-profile/public-profile.html
@@ -120,6 +120,42 @@
         </div>
       </div>
 
+      <!-- Daily oggi: visibile solo se l'utente visualizzato ha completato la
+           sfida del giorno corrente. Se anche io l'ho fatta, mostro il
+           confronto a due. Se sono io stesso (isSelf), niente: il mio daily lo
+           vedo gia' su /daily-result. -->
+      @if (!isSelf() && p.dailyToday; as theirDaily) {
+        <div class="pub-daily-card">
+          <span class="eyebrow pub-daily-eyebrow">
+            {{ i18n.lang() === 'it' ? 'SFIDA GIORNALIERA · OGGI' : 'DAILY · TODAY' }}
+          </span>
+          @if (myDailyToday(); as mine) {
+            <div class="pub-daily-vs">
+              <div class="pub-daily-side"
+                   [class.pub-daily-winner]="mine.score > theirDaily.score">
+                <span class="pub-daily-name">{{ i18n.lang() === 'it' ? 'Tu' : 'You' }}</span>
+                <span class="pub-daily-score tabnum">{{ mine.score }}/5</span>
+              </div>
+              <span class="pub-daily-vs-sep">vs</span>
+              <div class="pub-daily-side"
+                   [class.pub-daily-winner]="theirDaily.score > mine.score">
+                <span class="pub-daily-name">{{ p.nickname }}</span>
+                <span class="pub-daily-score tabnum">{{ theirDaily.score }}/5</span>
+              </div>
+            </div>
+          } @else {
+            <p class="pub-daily-solo">
+              {{ p.nickname }}
+              {{ i18n.lang() === 'it' ? 'ha fatto' : 'scored' }}
+              <strong class="tabnum">{{ theirDaily.score }}/5</strong>.
+              {{ i18n.lang() === 'it'
+                ? 'Vediamo come te la cavi.'
+                : "Let's see how you do." }}
+            </p>
+          }
+        </div>
+      }
+
       <div class="divider"></div>
 
       <h3 class="h3 pub-section-h">

--- a/src/app/features/public-profile/public-profile.ts
+++ b/src/app/features/public-profile/public-profile.ts
@@ -70,6 +70,15 @@ export class PublicProfile {
     this.scoreInfoOpen.set(false);
   }
 
+  /** Il MIO score della daily di oggi, se l'ho completata, dal mio AppState.
+   *  Serve a fare il confronto a fianco al daily dell'utente visualizzato. */
+  protected readonly myDailyToday = computed<{ score: number } | null>(() => {
+    const s = this.appState.state();
+    const today = new Date().toDateString();
+    if (s.dailyDoneStamp !== today) return null;
+    return { score: s.dailyScore };
+  });
+
   protected readonly isSelf = computed(() => {
     const p = this.profile();
     const me = this.appState.state().account?.uid;
@@ -161,6 +170,13 @@ export class PublicProfile {
         stateForBadges.correctAnswers + stateForBadges.bestStreak * 10;
       const score = typeof persistedScore === 'number' ? persistedScore : computedScore;
 
+      // Daily oggi: e' considerata "fatta" se lo stamp persistito su cloud
+      // corrisponde alla stringa di oggi (new Date().toDateString()). Cosi'
+      // un giorno dopo la conferma, il campo torna implicitamente a false e
+      // non mostriamo piu' un risultato stantio.
+      const todayStamp = new Date().toDateString();
+      const dailyDoneToday = stateForBadges.dailyDoneStamp === todayStamp;
+
       this.profile.set({
         uid: doc.uid,
         nickname: (doc as Record<string, string>)['nickname'] ?? nick,
@@ -171,6 +187,9 @@ export class PublicProfile {
         accuracy: stateForBadges.accuracy,
         played: stateForBadges.played,
         dailyStreak: stateForBadges.dailyStreak,
+        dailyToday: dailyDoneToday
+          ? { score: stateForBadges.dailyScore }
+          : null,
         unlockedBadges,
         totalBadges: allBadges.length,
         scriptStats,
@@ -325,6 +344,10 @@ interface PublicProfileData {
   accuracy: number;
   played: number;
   dailyStreak: number;
+  /** Risultato della sfida giornaliera di OGGI dell'utente visualizzato, se
+   *  l'ha completata. Null se non l'ha ancora giocata oggi (o se il campo
+   *  stale di un giorno precedente). */
+  dailyToday: { score: number } | null;
   unlockedBadges: BadgeWithProgress[];
   totalBadges: number;
   scriptStats: Array<{


### PR DESCRIPTION
Sezione "Sfida giornaliera · oggi" sul profilo pubblico di un utente.

UX

Compare sotto le stats 2x2 (best/precisione/partite/giorni di fila), prima di "Per scrittura".

- Se l'utente visualizzato NON ha fatto la daily oggi: niente, sezione assente.
- Se l'ha fatta e io NON l'ho fatta: messaggio "Nick ha fatto X/5. Vediamo come te la cavi."
- Se entrambi l'abbiamo fatta: due colonne "Tu / Nick" con score grande. Chi e' davanti ha lo score colorato in ambra.
- Sul mio stesso profilo (isSelf): niente, ho gia' /daily-result.

Tecnica

Nessuna query Firestore aggiuntiva: i campi dailyDoneStamp + dailyScore sono gia' nel doc /users letto da NicknameService.getUserByNickname. Il "ha giocato oggi" e' dailyDoneStamp === new Date().toDateString(): naturalmente diventa stale il giorno dopo, niente cleanup necessario.

Il MIO daily di oggi viene dal mio AppState locale (signal computed), zero overhead.