### PR TITLE
fix(public-profile): impedisci sfide duplicate verso lo stesso amico

### DIFF
--- a/src/app/core/firebase/challenges.service.ts
+++ b/src/app/core/firebase/challenges.service.ts
@@ -182,6 +182,20 @@ export class ChallengesService {
     return all.filter((c) => c.status === 'pending').length;
   }
 
+  /**
+   * True se esiste una sfida pending tra l'utente loggato e `friendUid`,
+   * in qualunque direzione. Usato dal profilo pubblico per impedire di
+   * mandare una seconda sfida quando una e' gia' in corso.
+   */
+  async existsPendingWith(friendUid: string): Promise<boolean> {
+    const me = this.appState.state().account?.uid;
+    if (!me) return false;
+    const [inc, out] = await Promise.all([this.listIncoming(), this.listOutgoing()]);
+    const fromHim = inc.some((c) => c.status === 'pending' && c.from === friendUid);
+    const fromMe = out.some((c) => c.status === 'pending' && c.to === friendUid);
+    return fromHim || fromMe;
+  }
+
   /** Risposta del destinatario alla sfida: setta toScore e segna completed. */
   async submitToScore(id: string, toScore: number): Promise<void> {
     if (!this.db) throw new Error('Firebase not configured');

--- a/src/app/features/public-profile/public-profile.html
+++ b/src/app/features/public-profile/public-profile.html
@@ -59,11 +59,21 @@
                       (click)="removeFriend()">
                 ✓ {{ i18n.lang() === 'it' ? 'Siete amici' : 'Friends' }}
               </button>
-              <button class="btn btn-primary pub-friend-btn"
-                      type="button"
-                      (click)="challengeFriend()">
-                {{ i18n.lang() === 'it' ? 'Sfida' : 'Challenge' }}
-              </button>
+              @if (pendingChallenge() === true) {
+                <button class="nav-btn pub-friend-btn"
+                        type="button"
+                        disabled
+                        (click)="goChallenges()"
+                        [attr.aria-label]="i18n.lang() === 'it' ? 'Sfida gia\' in corso' : 'Challenge already pending'">
+                  {{ i18n.lang() === 'it' ? 'Sfida in corso' : 'Pending' }}
+                </button>
+              } @else {
+                <button class="btn btn-primary pub-friend-btn"
+                        type="button"
+                        (click)="challengeFriend()">
+                  {{ i18n.lang() === 'it' ? 'Sfida' : 'Challenge' }}
+                </button>
+              }
             }
             @case ('pending-sent') {
               <button class="nav-btn pub-friend-btn"

--- a/src/app/features/public-profile/public-profile.ts
+++ b/src/app/features/public-profile/public-profile.ts
@@ -7,6 +7,7 @@ import { I18nService } from '../../core/i18n/i18n.service';
 import { AppStateService } from '../../core/state/app-state.service';
 import { NicknameService } from '../../core/firebase/nickname.service';
 import { FriendStatus, FriendsService } from '../../core/firebase/friends.service';
+import { ChallengesService } from '../../core/firebase/challenges.service';
 import { avatarById } from '../../core/data/avatars';
 import { BadgeWithProgress, computeBadges } from '../../core/data/badges';
 import { ScriptInfo, scriptById } from '../../core/data/scripts';
@@ -35,6 +36,7 @@ export class PublicProfile {
   protected readonly appState = inject(AppStateService);
   private readonly nicknames = inject(NicknameService);
   private readonly friends = inject(FriendsService);
+  private readonly challenges = inject(ChallengesService);
 
   /** Param `:nickname` dalla rotta, in formato URL-encoded come arriva. */
   protected readonly nickname = toSignal(
@@ -51,6 +53,12 @@ export class PublicProfile {
   protected readonly friendStatus = signal<FriendStatus | null>(null);
   /** Lock per evitare doppi-click sui bottoni amicizia. */
   protected readonly friendBusy = signal(false);
+
+  /** Esiste gia' una sfida pending con questo utente (in qualunque direzione)?
+   *  Caricato lazy dopo il fetch del profilo. Mentre e' `null` = "non lo so
+   *  ancora"; il bottone "Sfida" resta normale. Quando passa a `true` lo
+   *  disabilitiamo per evitare sfide duplicate. */
+  protected readonly pendingChallenge = signal<boolean | null>(null);
 
   /** Modale "come si calcolano i punti": tap sulla card Punti la apre. */
   protected readonly scoreInfoOpen = signal(false);
@@ -111,6 +119,7 @@ export class PublicProfile {
       this.notFound.set(false);
       this.profile.set(null);
       this.friendStatus.set(null);
+      this.pendingChallenge.set(null);
       void this.fetch(n);
     });
   }
@@ -180,6 +189,18 @@ export class PublicProfile {
         try {
           const status = await this.friends.statusWith(doc.uid);
           this.friendStatus.set(status);
+          // Se siamo amici, verifico anche se c'e' gia' una sfida pending fra
+          // di noi (in qualunque direzione), per disabilitare il bottone
+          // "Sfida" ed evitare di crearne una seconda.
+          if (status === 'accepted') {
+            try {
+              const exists = await this.challenges.existsPendingWith(doc.uid);
+              this.pendingChallenge.set(exists);
+            } catch (e) {
+              console.warn('[public-profile] pending challenge check error:', e);
+              this.pendingChallenge.set(false);
+            }
+          }
         } catch (e) {
           console.warn('[public-profile] friend status error:', e);
         }
@@ -244,6 +265,12 @@ export class PublicProfile {
     const p = this.profile();
     if (!p) return;
     this.router.navigate(['/sfida/nuova', p.nickname]);
+  }
+
+  /** Navigazione alla lista sfide, usata dal bottone disabilitato "Sfida in
+   *  corso" come hint per dove ritrovare la pending. */
+  protected goChallenges(): void {
+    this.router.navigate(['/sfide']);
   }
 
   /** Rimuove l'amicizia (gia' accettata). */


### PR DESCRIPTION
Edge case rilevato dopo aver mergiato la PR sulle sfide. Oggi nulla impedisce di mandare 10 sfide consecutive allo stesso amico: lo spammeresti di pending mai gestite.

Soluzione: dopo aver letto lo stato amicizia, se 'accepted' faccio una seconda lettura che cerca tra incoming + outgoing una sfida pending verso questo utente (in qualunque direzione). Se la trovo, il bottone "Sfida" diventa "Sfida in corso" disabled. Quando l'altro gioca e la sfida passa a completed, ricaricando il profilo torna attivo.

Tecnica

Nuovo metodo `ChallengesService.existsPendingWith(friendUid)` che riusa listIncoming + listOutgoing. Costo: 2 read Firestore in piu' al caricamento del profilo, ma solo se siamo amici (status accepted). Nessuna nuova rule.

Non e' un controllo server-side: se due tab aperte mandano due sfide in parallelo, possono creare entrambe. Per garanzia completa servirebbe una pre-check transazionale, ma overkill per uno scenario raro e benigno (al limite vede due sfide in /sfide).