### PR TITLE
feat(sfide): revoca sfide pending inviate

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -80,7 +80,12 @@ service cloud.firestore {
                     && request.resource.data.to == resource.data.to
                     && request.resource.data.fromScore == resource.data.fromScore
                     && request.resource.data.questions == resource.data.questions;
-      allow delete: if false;
+      // Solo il challenger (from) puo' revocare una sfida ancora pending.
+      // Una sfida gia' completata dal destinatario non si tocca, resta nello
+      // storico di entrambi.
+      allow delete: if request.auth != null
+                    && request.auth.uid == resource.data.from
+                    && resource.data.status == 'pending';
     }
 
     // /feedback/{auto-id}

--- a/src/app/core/firebase/challenges.service.ts
+++ b/src/app/core/firebase/challenges.service.ts
@@ -3,6 +3,7 @@ import {
   Firestore,
   addDoc,
   collection,
+  deleteDoc,
   doc,
   getDoc,
   getDocs,
@@ -217,6 +218,20 @@ export class ChallengesService {
       else draw++;
     }
     return { won, lost, draw, total: won + lost + draw };
+  }
+
+  /**
+   * Revoca una sfida pending che il challenger ha inviato. Cancella il doc
+   * Firestore. Le rules consentono delete solo se `auth.uid === from` E
+   * `status === 'pending'`: una sfida gia' giocata dal destinatario non
+   * puo' piu' essere annullata. Idempotente lato client: se il doc non
+   * esiste piu' (es. l'altro l'ha gia' completata nel frattempo), la
+   * delete fallisce silently e l'UI ricarica lo stato fresco.
+   */
+  async cancelOutgoing(id: string): Promise<void> {
+    if (!this.db) throw new Error('Firebase not configured');
+    const ref = doc(this.db, 'challenges', id);
+    await deleteDoc(ref);
   }
 
   /** Risposta del destinatario alla sfida: setta toScore e segna completed. */

--- a/src/app/features/challenges-list/challenges-list.css
+++ b/src/app/features/challenges-list/challenges-list.css
@@ -141,3 +141,38 @@
   border-color: var(--border);
   background: var(--surface-2);
 }
+
+/* Bottone "Annulla" sulla riga delle sfide inviate pending. Stile sobrio (no
+   primary), color text-dim per non rubare attenzione alla riga stessa. Hover
+   passa al rosso per segnalare la natura distruttiva dell'azione. */
+.cl-revoke {
+  appearance: none;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text-dim);
+  font: inherit;
+  font-size: 12px;
+  font-weight: 500;
+  padding: 6px 10px;
+  border-radius: 8px;
+  cursor: pointer;
+  transition:
+    color var(--hover-dur) ease,
+    border-color var(--hover-dur) ease,
+    background var(--hover-dur) ease;
+}
+.cl-revoke:hover:not(:disabled) {
+  color: var(--bad);
+  border-color: var(--bad);
+  background: rgba(239, 68, 68, 0.06);
+}
+.cl-revoke:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+/* Adatta la riga statica delle sfide inviate al nuovo terzo elemento (bottone
+   Annulla a destra): tre colonne invece di due. */
+.cl-row-static {
+  grid-template-columns: 40px 1fr auto;
+}

--- a/src/app/features/challenges-list/challenges-list.html
+++ b/src/app/features/challenges-list/challenges-list.html
@@ -108,6 +108,15 @@
                         <strong>{{ c.fromScore }}/5</strong>
                       </span>
                     </span>
+                    <button class="cl-revoke"
+                            type="button"
+                            [disabled]="cancelling().has(c.id)"
+                            (click)="revokeOutgoing(c, $event)"
+                            [attr.aria-label]="i18n.lang() === 'it' ? 'Annulla sfida' : 'Cancel challenge'">
+                      {{ cancelling().has(c.id)
+                          ? (i18n.lang() === 'it' ? 'Annullo…' : 'Cancelling…')
+                          : (i18n.lang() === 'it' ? 'Annulla' : 'Cancel') }}
+                    </button>
                   </div>
                 </li>
               }

--- a/src/app/features/challenges-list/challenges-list.ts
+++ b/src/app/features/challenges-list/challenges-list.ts
@@ -40,6 +40,10 @@ export class ChallengesList {
   protected readonly outgoing = signal<ChallengeDoc[]>([]);
   protected readonly loading = signal(true);
 
+  /** Set di id sfida in fase di revoca: usato per disabilitare il bottone
+   *  "Annulla" durante la delete e per nascondere ottimisticamente la riga. */
+  protected readonly cancelling = signal<Set<string>>(new Set());
+
   protected readonly pendingIncoming = computed(() =>
     this.incoming().filter((c) => c.status === 'pending'),
   );
@@ -101,6 +105,37 @@ export class ChallengesList {
 
   protected openChallenge(id: string): void {
     this.router.navigate(['/sfida', id]);
+  }
+
+  /** Revoca una sfida pending inviata dall'utente. Chiede conferma via
+   *  window.confirm (semplice, niente dialog dedicato per uno scope cosi'
+   *  ristretto). Dopo la delete, rimuove ottimisticamente la riga dalla
+   *  lista; se la delete fallisce, la lista viene comunque ricaricata. */
+  protected async revokeOutgoing(c: ChallengeDoc, event: Event): Promise<void> {
+    event.stopPropagation();
+    const isIt = this.i18n.lang() === 'it';
+    const msg = isIt
+      ? `Annullare la sfida a ${c.toNickname}? Il tuo punteggio (${c.fromScore}/5) andra' perso.`
+      : `Cancel the challenge to ${c.toNickname}? Your score (${c.fromScore}/5) will be discarded.`;
+    if (typeof window !== 'undefined' && !window.confirm(msg)) return;
+    if (this.cancelling().has(c.id)) return;
+    this.cancelling.update((s) => new Set(s).add(c.id));
+    try {
+      await this.challenges.cancelOutgoing(c.id);
+      // Rimuovi ottimisticamente dalla lista locale, evita re-fetch costoso.
+      this.outgoing.update((list) => list.filter((x) => x.id !== c.id));
+    } catch (e) {
+      console.warn('[challenges-list] revoke error:', e);
+      // Refresh per allineare lo stato in caso la delete sia comunque andata
+      // a buon fine, o la sfida sia stata gia' completata nel frattempo.
+      void this.refresh();
+    } finally {
+      this.cancelling.update((s) => {
+        const next = new Set(s);
+        next.delete(c.id);
+        return next;
+      });
+    }
   }
 
   protected openFriend(nickname: string): void {


### PR DESCRIPTION
Edge case lasciato fuori dal trittico amici. Oggi se mandi una sfida e poi cambi idea, non puoi piu' annullarla: resta li a infestare /sfide tab "Inviate" forever (o finche' l'altro la gioca).

UX

Nel tab "Inviate" di /sfide, ogni riga ha un piccolo bottone "Annulla" a destra (sobrio, grigio, hover rosso). Tap: window.confirm con messaggio "Annullare la sfida a Nick? Il tuo punteggio andra' perso", poi delete. La riga sparisce ottimisticamente. Se fallisce, la lista si ri-fetcha per allineare lo stato.

Non c'e' il bottone Annulla sulle sfide gia' completate (sono nello "Storico", non in "Inviate"): non si toccano, sono record permanenti per entrambi.

Tecnica

Nuovo metodo `ChallengesService.cancelOutgoing(id)` che fa una delete su `/challenges/{id}`. Nuova regola Firestore:

```
allow delete: if request.auth != null
              && request.auth.uid == resource.data.from
              && resource.data.status == 'pending';
```

Il destinatario NON puo' cancellare (solo il challenger). Una sfida completata NON puo' essere cancellata da nessuno (entrambi vogliono mantenerla nello storico).

Race condition: se il destinatario gioca proprio mentre il challenger annulla, la delete fallisce (lo status non e' piu' pending) e l'UI fa refresh. Comportamento corretto: la sfida finisce in "Storico" e basta.

Da deployare

```bash
npm run deploy:rules
```

dopo il merge per applicare la nuova regola di delete.