### PR TITLE
feat(login): flow 'Password dimenticata?' con email di reset

### DIFF
--- a/src/app/core/firebase/auth.service.ts
+++ b/src/app/core/firebase/auth.service.ts
@@ -6,6 +6,7 @@ import {
   createUserWithEmailAndPassword,
   getAuth,
   onAuthStateChanged,
+  sendPasswordResetEmail,
   signInWithEmailAndPassword,
   signInWithPopup,
   signOut as fbSignOut,
@@ -74,6 +75,21 @@ export class AuthService {
   async signOut(): Promise<void> {
     if (!this.auth) return;
     await fbSignOut(this.auth);
+  }
+
+  /**
+   * Manda il classico "email di reset password" all'indirizzo dato. Firebase
+   * non ritorna feedback diverso a seconda che l'email esista o no (scelta
+   * voluta per privacy: non vogliamo che un attaccante possa enumerare gli
+   * account registrati). Quindi la UI dice sempre "se l'email esiste, hai
+   * ricevuto un link" indipendentemente dal risultato.
+   *
+   * Lancia comunque per i casi di errore reale (formato email invalido,
+   * rate limit, network), che la UI mappa a messaggi specifici.
+   */
+  async sendPasswordReset(email: string): Promise<void> {
+    const auth = this.requireAuth();
+    await sendPasswordResetEmail(auth, email);
   }
 
   private requireAuth(): Auth {

--- a/src/app/core/firebase/auth.service.ts
+++ b/src/app/core/firebase/auth.service.ts
@@ -84,11 +84,16 @@ export class AuthService {
    * account registrati). Quindi la UI dice sempre "se l'email esiste, hai
    * ricevuto un link" indipendentemente dal risultato.
    *
+   * `languageCode` ('it' / 'en' / ecc.) seleziona la lingua del template
+   * della mail. Firebase ha gia' i template tradotti per ~50 lingue
+   * (incluse IT + EN), quindi non c'e' nulla da configurare lato console.
+   *
    * Lancia comunque per i casi di errore reale (formato email invalido,
    * rate limit, network), che la UI mappa a messaggi specifici.
    */
-  async sendPasswordReset(email: string): Promise<void> {
+  async sendPasswordReset(email: string, languageCode?: string): Promise<void> {
     const auth = this.requireAuth();
+    if (languageCode) auth.languageCode = languageCode;
     await sendPasswordResetEmail(auth, email);
   }
 

--- a/src/app/features/login/login.css
+++ b/src/app/features/login/login.css
@@ -228,3 +228,57 @@
   color: var(--text);
   background: var(--surface-2);
 }
+
+/* Link "Password dimenticata?" sotto il campo password: piccolo, sobrio,
+   allineato a destra. Non un link <a> (rimane nel form), e' un button con
+   look da link. */
+.login-forgot {
+  align-self: flex-end;
+  appearance: none;
+  background: transparent;
+  border: 0;
+  padding: 4px 0;
+  margin-top: -4px;
+  color: var(--text-dim);
+  font: inherit;
+  font-size: 12px;
+  cursor: pointer;
+  text-decoration: underline;
+  text-decoration-color: var(--border-strong);
+  text-underline-offset: 3px;
+  transition: color var(--hover-dur) ease;
+}
+.login-forgot:hover {
+  color: var(--accent);
+}
+
+/* Modale reset password: stessa estetica di InfoSheet, ma piu' grande per
+   ospitare il form. */
+.reset-backdrop {
+  align-items: center;
+  z-index: 90;
+}
+.reset-sheet {
+  max-width: 380px;
+  border-radius: 20px;
+  padding: 22px;
+  animation: pop 0.18s ease;
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.reset-title {
+  margin: 0;
+}
+.reset-sub {
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.5;
+}
+.reset-actions {
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
+  margin-top: 4px;
+}

--- a/src/app/features/login/login.html
+++ b/src/app/features/login/login.html
@@ -131,6 +131,12 @@
           </div>
         </label>
 
+        <!-- Link "Password dimenticata?" piccolino, allineato a destra sotto il
+             campo password. Apre la modale di reset. -->
+        <button type="button" class="login-forgot" (click)="openReset()">
+          {{ i18n.lang() === 'it' ? 'Password dimenticata?' : 'Forgot password?' }}
+        </button>
+
         @if (error(); as e) {
           <p class="login-error" role="alert">{{ e }}</p>
         }
@@ -160,4 +166,67 @@
       }
     </div>
   </div>
+
+  <!-- Modale "Password dimenticata?". Riusa le classi .sheet-backdrop / .sheet
+       gia' definite nello stile globale, stessa estetica di InfoSheet ecc. -->
+  @if (resetOpen()) {
+    <div class="sheet-backdrop reset-backdrop" (click)="closeReset()">
+      <div class="sheet reset-sheet" (click)="$event.stopPropagation()">
+        <h2 class="h2 reset-title">
+          {{ i18n.lang() === 'it' ? 'Reimposta la password' : 'Reset your password' }}
+        </h2>
+
+        @if (resetDone()) {
+          <p class="muted reset-sub">
+            {{ i18n.lang() === 'it'
+              ? 'Se esiste un account con questa email, ti abbiamo mandato un link per scegliere una nuova password. Controlla anche lo spam.'
+              : 'If an account exists for this email, we sent a link to set a new password. Check your spam folder too.' }}
+          </p>
+          <button type="button" class="btn btn-primary btn-block" (click)="closeReset()">
+            {{ i18n.lang() === 'it' ? 'Chiudi' : 'Close' }}
+          </button>
+        } @else {
+          <p class="muted reset-sub">
+            {{ i18n.lang() === 'it'
+              ? 'Inserisci la tua email: ti mandiamo un link per impostare una nuova password.'
+              : 'Enter your email: we will send a link to set a new password.' }}
+          </p>
+
+          <form (ngSubmit)="submitReset()">
+            <label class="login-field">
+              <span class="login-field-label">Email</span>
+              <input
+                type="email"
+                autocomplete="email"
+                class="input-field"
+                placeholder="tu@esempio.it"
+                [ngModel]="resetEmail()"
+                (ngModelChange)="setResetEmail($event)"
+                name="resetEmail"
+                required
+                autofocus
+              />
+            </label>
+
+            @if (resetError(); as e) {
+              <p class="login-error" role="alert">{{ e }}</p>
+            }
+
+            <div class="reset-actions">
+              <button type="button" class="btn btn-ghost" (click)="closeReset()" [disabled]="resetBusy()">
+                {{ i18n.lang() === 'it' ? 'Annulla' : 'Cancel' }}
+              </button>
+              <button type="submit" class="btn btn-primary" [disabled]="!resetEmailValid() || resetBusy()">
+                @if (resetBusy()) {
+                  {{ i18n.lang() === 'it' ? 'Invio…' : 'Sending…' }}
+                } @else {
+                  {{ i18n.lang() === 'it' ? 'Invia link' : 'Send link' }}
+                }
+              </button>
+            </div>
+          </form>
+        }
+      </div>
+    </div>
+  }
 </div>

--- a/src/app/features/login/login.ts
+++ b/src/app/features/login/login.ts
@@ -28,8 +28,68 @@ export class Login {
   protected readonly busy = signal(false);
   protected readonly error = signal<string | null>(null);
 
+  /** Modal "Password dimenticata?": stato proprio, indipendente dal form
+   *  principale. Email precompilata con quella del form se l'utente l'ha
+   *  gia' inserita, altrimenti vuota. */
+  protected readonly resetOpen = signal(false);
+  protected readonly resetEmail = signal('');
+  protected readonly resetBusy = signal(false);
+  protected readonly resetDone = signal(false);
+  protected readonly resetError = signal<string | null>(null);
+
   protected toggleShowPassword(): void {
     this.showPassword.update((v) => !v);
+  }
+
+  protected openReset(): void {
+    this.resetEmail.set(this.email() || '');
+    this.resetError.set(null);
+    this.resetDone.set(false);
+    this.resetOpen.set(true);
+  }
+
+  protected closeReset(): void {
+    this.resetOpen.set(false);
+  }
+
+  protected setResetEmail(v: string): void {
+    this.resetEmail.set(v);
+    if (this.resetError()) this.resetError.set(null);
+  }
+
+  protected readonly resetEmailValid = computed(() =>
+    /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(this.resetEmail()),
+  );
+
+  /**
+   * Manda l'email di reset. Firebase non fa enumeration leak: la stessa risposta
+   * (success) torna sia se l'email esiste sia se no. Quindi mostriamo sempre
+   * "controlla la mail" indipendentemente dal vero risultato lato Firebase.
+   * Eccezione: errori reali come formato invalido / rate limit / network li
+   * mostriamo all'utente cosi' sa che il bottone non e' stato silenziosamente
+   * ignorato.
+   */
+  protected async submitReset(): Promise<void> {
+    if (!this.resetEmailValid() || this.resetBusy()) return;
+    this.resetBusy.set(true);
+    this.resetError.set(null);
+    const email = this.resetEmail().trim();
+    try {
+      await this.auth.sendPasswordReset(email);
+      this.resetDone.set(true);
+    } catch (e: unknown) {
+      const code = (e as { code?: string })?.code ?? '';
+      // auth/user-not-found NON arriva in pratica con sendPasswordResetEmail
+      // su Firebase moderno (privacy), ma lo trattiamo come "fingiamo
+      // success" se mai dovesse arrivare, cosi' resta coerente con il resto.
+      if (code === 'auth/user-not-found' || code === 'auth/invalid-credential') {
+        this.resetDone.set(true);
+      } else {
+        this.resetError.set(this.translateError(e));
+      }
+    } finally {
+      this.resetBusy.set(false);
+    }
   }
 
   /** Se siamo gia' autenticati: tornare al rendering qui dentro significa che

--- a/src/app/features/login/login.ts
+++ b/src/app/features/login/login.ts
@@ -75,7 +75,7 @@ export class Login {
     this.resetError.set(null);
     const email = this.resetEmail().trim();
     try {
-      await this.auth.sendPasswordReset(email);
+      await this.auth.sendPasswordReset(email, this.i18n.lang());
       this.resetDone.set(true);
     } catch (e: unknown) {
       const code = (e as { code?: string })?.code ?? '';


### PR DESCRIPTION
Chi crea un account email+password e dimentica la password oggi perde l'account: nessun flow di recupero. Questo PR lo aggiunge usando il `sendPasswordResetEmail` built-in di Firebase.

UX

In /login, sotto il campo password, piccolo link "Password dimenticata?" allineato a destra (sobrio, underlined, hover ambra). Tap: modale stile InfoSheet con campo email precompilato (se l'utente l'aveva gia' digitato sopra), bottone "Invia link" / "Annulla". Submit:

- Firebase manda la mail con il link di reset standard.
- La modale passa a "Se esiste un account con questa email, ti abbiamo mandato un link". Stesso messaggio per email esistente o no: scelta voluta di privacy (no account enumeration).
- Per errori reali (formato email invalido, rate limit, network) mostriamo invece il messaggio specifico cosi' l'utente sa che il bottone non e' stato silently ignorato.

Lato Firebase Console: il template della mail (Authentication > Templates > Password reset) e' quello di default. Funziona, ma se vogliamo possiamo tradurlo in italiano dalla console (zero codice).

Tecnica

Nuovo metodo `AuthService.sendPasswordReset(email)`, thin wrapper su `sendPasswordResetEmail` di firebase/auth. Niente nuove dipendenze, niente Firestore involved. Stato del flow gestito con quattro signals locali al componente (open / busy / done / error).