### PR TITLE
chore(android): aggiungi SHA-256 fingerprint della keystore di produzione

### DIFF
--- a/public/.well-known/assetlinks.json
+++ b/public/.well-known/assetlinks.json
@@ -5,7 +5,7 @@
       "namespace": "android_app",
       "package_name": "io.github.alessiopesit_boop.guessthechar",
       "sha256_cert_fingerprints": [
-        "PLACEHOLDER_REPLACE_WITH_SHA256_FROM_YOUR_RELEASE_KEYSTORE"
+        "D2:76:57:EB:FD:AC:C6:44:8F:A2:E8:F6:93:1E:E7:19:CA:56:F8:EA:2F:00:E1:E2:4F:B9:A2:37:FD:22:B3:DF"
       ]
     }
   }


### PR DESCRIPTION
Sostituisce il placeholder in assetlinks.json con il fingerprint reale della keystore generata per Google Play. Da questo momento Asset Links e' pronto a essere validato dal browser Chrome quando l'app TWA verra' installata dal Play Store.

Nota: il file canonico va servito a root del dominio alessiopesit-boop.github.io (repo profilo, gia' creato e deployato), non sotto /guess-the-char/, ma teniamo entrambe le copie cosi' una doppia verifica e' sempre possibile.