### PR TITLE
fix(ci): pre-configura Bubblewrap per saltare il prompt JDK/SDK interattivo

### DIFF
--- a/.github/workflows/play-release.yml
+++ b/.github/workflows/play-release.yml
@@ -46,6 +46,23 @@ jobs:
       - name: Install Bubblewrap CLI
         run: npm install -g @bubblewrap/cli@latest
 
+      - name: Pre-configura Bubblewrap (skip prompt JDK/SDK)
+        run: |
+          # Al primo avvio, Bubblewrap chiede interattivamente se vuoi che si
+          # installi un proprio JDK + SDK. In CI non lo vogliamo: usiamo quelli
+          # gia' messi sul runner dai due step precedenti. Pre-popoliamo il
+          # config file in $HOME/.bubblewrap/config.json cosi' il prompt salta
+          # e l'update parte dritto.
+          mkdir -p "$HOME/.bubblewrap"
+          cat > "$HOME/.bubblewrap/config.json" <<EOF
+          {
+            "jdkPath": "${JAVA_HOME}",
+            "androidSdkPath": "${ANDROID_SDK_ROOT}"
+          }
+          EOF
+          echo "Config Bubblewrap:"
+          cat "$HOME/.bubblewrap/config.json"
+
       - name: Decode keystore from secret
         env:
           KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}


### PR DESCRIPTION
Al primo avvio Bubblewrap CLI chiede in modo interattivo se installare un proprio JDK, bloccando la pipeline CI (exit 130 / SIGINT) allo step 'Genera progetto Android via Bubblewrap update'. Scriviamo a mano il config file in \`~/.bubblewrap/config.json\` prima di chiamare \`update\`, puntandolo al JDK + Android SDK gia' messi sul runner dai due step precedenti. Cosi' il prompt salta e il workflow procede dritto al build dell'AAB.