### PR TITLE
fix(android): porta minSdkVersion da 19 a 21

### DIFF
--- a/twa-manifest.json
+++ b/twa-manifest.json
@@ -32,7 +32,7 @@
   "isChromeOSOnly": false,
   "isMetaQuest": false,
   "fullScopeUrl": "https://alessiopesit-boop.github.io/guess-the-char/",
-  "minSdkVersion": 19,
+  "minSdkVersion": 21,
   "orientation": "any",
   "fingerprints": []
 }


### PR DESCRIPTION
La libreria androidbrowserhelper 2.6.2 (parte di Bubblewrap) richiede minSdkVersion 21. Con 19 il build dell'AAB falliva con 'Manifest merger failed'. API 21 (Lollipop) e' attiva su >99% dei device Android attualmente in uso, quindi nessuna perdita pratica di compatibilita'.