### PR TITLE
chore(android): aggiungi SHA-256 della Play app signing key agli Asset Links

### DIFF
--- a/public/.well-known/assetlinks.json
+++ b/public/.well-known/assetlinks.json
@@ -5,7 +5,8 @@
       "namespace": "android_app",
       "package_name": "io.github.alessiopesit_boop.guessthechar",
       "sha256_cert_fingerprints": [
-        "D2:76:57:EB:FD:AC:C6:44:8F:A2:E8:F6:93:1E:E7:19:CA:56:F8:EA:2F:00:E1:E2:4F:B9:A2:37:FD:22:B3:DF"
+        "D2:76:57:EB:FD:AC:C6:44:8F:A2:E8:F6:93:1E:E7:19:CA:56:F8:EA:2F:00:E1:E2:4F:B9:A2:37:FD:22:B3:DF",
+        "2F:57:F3:B2:45:07:6D:20:06:55:DB:2E:C4:30:EF:37:61:39:0E:B7:9B:9F:1B:45:E4:50:E4:CD:62:F2:EC:71"
       ]
     }
   }


### PR DESCRIPTION
Aggiunge il fingerprint SHA-256 della chiave di firma di Google Play (Play App Signing) all'array degli Asset Links, accanto alla upload key gia' presente. Serve perche' l'app distribuita dallo Store e' ri-firmata da Google: senza questo fingerprint la TWA scaricata dal Play Store si aprirebbe con la barra del browser invece che full-screen.

Nota: la copia che la TWA verifica davvero e' quella alla root del dominio (repo profilo alessiopesit-boop.github.io, gia' aggiornata). Questa e' la copia di questo repo, allineata per coerenza.